### PR TITLE
[Step3] 버그 수정과 테스트 보강

### DIFF
--- a/src/main/java/com/camping/legacy/controller/ReservationController.java
+++ b/src/main/java/com/camping/legacy/controller/ReservationController.java
@@ -66,9 +66,9 @@ public class ReservationController {
     @DeleteMapping("/{id}")
     public ResponseEntity<?> cancelReservation(
             @PathVariable Long id,
-            @RequestParam String confirmationCode) {
+            @RequestParam String confirmationCode, @RequestParam String customerName) {
         try {
-            Reservation reservation = reservationService.cancelReservation(id, confirmationCode);
+            Reservation reservation = reservationService.cancelReservation(id, confirmationCode, customerName);
             Map<String, String> response = new HashMap<>();
             String canceledMessage = "예약이 취소되었습니다.";
             if(reservation.getStatus() == "CANCELLED_SAME_DAY") {

--- a/src/main/java/com/camping/legacy/controller/ReservationController.java
+++ b/src/main/java/com/camping/legacy/controller/ReservationController.java
@@ -1,5 +1,6 @@
 package com.camping.legacy.controller;
 
+import com.camping.legacy.domain.Reservation;
 import com.camping.legacy.dto.CalendarResponse;
 import com.camping.legacy.dto.ReservationRequest;
 import com.camping.legacy.dto.ReservationResponse;
@@ -67,9 +68,13 @@ public class ReservationController {
             @PathVariable Long id,
             @RequestParam String confirmationCode) {
         try {
-            reservationService.cancelReservation(id, confirmationCode);
+            Reservation reservation = reservationService.cancelReservation(id, confirmationCode);
             Map<String, String> response = new HashMap<>();
-            response.put("message", "예약이 취소되었습니다.");
+            String canceledMessage = "예약이 취소되었습니다.";
+            if(reservation.getStatus() == "CANCELLED_SAME_DAY") {
+                canceledMessage = "예약이 취소되었습니다. 예약 당일 취소는 환불이 불가능 합니다.";
+            }
+            response.put("message", canceledMessage);
             return ResponseEntity.ok(response);
         } catch (RuntimeException e) {
             Map<String, String> error = new HashMap<>();

--- a/src/main/java/com/camping/legacy/repository/CampsiteRepository.java
+++ b/src/main/java/com/camping/legacy/repository/CampsiteRepository.java
@@ -1,13 +1,15 @@
 package com.camping.legacy.repository;
 
 import com.camping.legacy.domain.Campsite;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
 public interface CampsiteRepository extends JpaRepository<Campsite, Long> {
-    
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Campsite> findBySiteNumber(String siteNumber);
 }

--- a/src/main/java/com/camping/legacy/repository/ReservationRepository.java
+++ b/src/main/java/com/camping/legacy/repository/ReservationRepository.java
@@ -17,9 +17,12 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     List<Reservation> findByCampsiteAndStartDateLessThanEqualAndEndDateGreaterThanEqual(Campsite campsite, LocalDate endDate, LocalDate startDate);
     
     Optional<Reservation> findByCampsiteIdAndStartDateLessThanEqualAndEndDateGreaterThanEqual(Long campsiteId, LocalDate endDate, LocalDate startDate);
-    
-    boolean existsByCampsiteAndStartDateLessThanEqualAndEndDateGreaterThanEqual(Campsite campsite, LocalDate endDate, LocalDate startDate);
-    
+
+    boolean existsByCampsiteAndStartDateLessThanEqualAndEndDateGreaterThanEqualAndStatusNot(
+            Campsite campsite,
+            LocalDate endDate,
+            LocalDate startDate,
+            String status);
     List<Reservation> findByCustomerName(String customerName);
     
     List<Reservation> findByCustomerNameAndPhoneNumber(String customerName, String phoneNumber);

--- a/src/main/java/com/camping/legacy/service/ReservationService.java
+++ b/src/main/java/com/camping/legacy/service/ReservationService.java
@@ -37,6 +37,10 @@ public class ReservationService {
         if (startDate == null || endDate == null) {
             throw new RuntimeException("예약 기간을 선택해주세요.");
         }
+
+        if (startDate.isAfter(LocalDate.now().plusDays(30))) {
+            throw new RuntimeException("예약은 오늘부터 30일 이내에만 가능합니다.");
+        }
         
         if (endDate.isBefore(startDate)) {
             throw new RuntimeException("종료일이 시작일보다 이전일 수 없습니다.");

--- a/src/main/java/com/camping/legacy/service/ReservationService.java
+++ b/src/main/java/com/camping/legacy/service/ReservationService.java
@@ -26,7 +26,7 @@ public class ReservationService {
     
     private static final int MAX_RESERVATION_DAYS = 30;
     
-    public ReservationResponse createReservation(ReservationRequest request) {
+    public synchronized ReservationResponse createReservation(ReservationRequest request) {
         String siteNumber = request.getSiteNumber();
         Campsite campsite = campsiteRepository.findBySiteNumber(siteNumber)
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 캠핑장입니다."));

--- a/src/main/java/com/camping/legacy/service/ReservationService.java
+++ b/src/main/java/com/camping/legacy/service/ReservationService.java
@@ -107,14 +107,18 @@ public class ReservationService {
                 .collect(Collectors.toList());
     }
     
-    public Reservation cancelReservation(Long id, String confirmationCode) {
+    public Reservation cancelReservation(Long id, String confirmationCode, String customerName) {
         Reservation reservation = reservationRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("예약을 찾을 수 없습니다."));
         
         if (!reservation.getConfirmationCode().equals(confirmationCode)) {
             throw new RuntimeException("확인 코드가 일치하지 않습니다.");
         }
-        
+
+        if (!reservation.getCustomerName().equals(customerName)) {
+            throw new RuntimeException("예약자 본인만 수정/취소가 가능합니다.");
+        }
+
         LocalDate today = LocalDate.now();
         if (reservation.getStartDate().equals(today)) {
             reservation.setStatus("CANCELLED_SAME_DAY");

--- a/src/main/java/com/camping/legacy/service/ReservationService.java
+++ b/src/main/java/com/camping/legacy/service/ReservationService.java
@@ -38,7 +38,7 @@ public class ReservationService {
             throw new RuntimeException("예약 기간을 선택해주세요.");
         }
 
-        if (startDate.isAfter(LocalDate.now().plusDays(30))) {
+        if (startDate.isAfter(LocalDate.now().plusDays(MAX_RESERVATION_DAYS))) {
             throw new RuntimeException("예약은 오늘부터 30일 이내에만 가능합니다.");
         }
 
@@ -53,9 +53,9 @@ public class ReservationService {
         if (request.getCustomerName() == null || request.getCustomerName().trim().isEmpty()) {
             throw new RuntimeException("예약자 이름을 입력해주세요.");
         }
-        
-        boolean hasConflict = reservationRepository.existsByCampsiteAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
-                campsite, endDate, startDate);
+
+        boolean hasConflict = reservationRepository.existsByCampsiteAndStartDateLessThanEqualAndEndDateGreaterThanEqualAndStatusNot(
+                campsite, endDate, startDate, "CANCELLED");
         if (hasConflict) {
             throw new RuntimeException("해당 기간에 이미 예약이 존재합니다.");
         }

--- a/src/main/java/com/camping/legacy/service/ReservationService.java
+++ b/src/main/java/com/camping/legacy/service/ReservationService.java
@@ -41,7 +41,11 @@ public class ReservationService {
         if (startDate.isAfter(LocalDate.now().plusDays(30))) {
             throw new RuntimeException("예약은 오늘부터 30일 이내에만 가능합니다.");
         }
-        
+
+        if (startDate.isBefore(LocalDate.now())) {
+            throw new RuntimeException("오늘 날짜 이후로 예약이 가능합니다.");
+        }
+
         if (endDate.isBefore(startDate)) {
             throw new RuntimeException("종료일이 시작일보다 이전일 수 없습니다.");
         }

--- a/src/main/java/com/camping/legacy/service/ReservationService.java
+++ b/src/main/java/com/camping/legacy/service/ReservationService.java
@@ -107,7 +107,7 @@ public class ReservationService {
                 .collect(Collectors.toList());
     }
     
-    public void cancelReservation(Long id, String confirmationCode) {
+    public Reservation cancelReservation(Long id, String confirmationCode) {
         Reservation reservation = reservationRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("예약을 찾을 수 없습니다."));
         
@@ -122,7 +122,7 @@ public class ReservationService {
             reservation.setStatus("CANCELLED");
         }
         
-        reservationRepository.save(reservation);
+        return reservationRepository.save(reservation);
     }
     
     // 고객 이름으로 예약 조회

--- a/src/main/java/com/camping/legacy/service/SiteService.java
+++ b/src/main/java/com/camping/legacy/service/SiteService.java
@@ -98,7 +98,7 @@ public class SiteService {
         Campsite campsite = campsiteRepository.findBySiteNumber(siteNumber)
                 .orElseThrow(() -> new RuntimeException("사이트를 찾을 수 없습니다: " + siteNumber));
         
-        return !reservationRepository.existsByCampsiteAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
-                campsite, date, date);
+        return !reservationRepository.existsByCampsiteAndStartDateLessThanEqualAndEndDateGreaterThanEqualAndStatusNot(
+                campsite, date, date, "CANCELLED");
     }
 }

--- a/src/test/java/com/camping/legacy/AbstractIntegrationTest.java
+++ b/src/test/java/com/camping/legacy/AbstractIntegrationTest.java
@@ -67,10 +67,11 @@ public abstract class AbstractIntegrationTest {
                 .extract();
     }
 
-    protected ExtractableResponse<Response> cancelReservation(Long reservationId, String confirmationCode) {
+    protected ExtractableResponse<Response> cancelReservation(Long reservationId, String confirmationCode, String customerName) {
         return RestAssured.given()
                 .contentType(ContentType.JSON)
                 .queryParam("confirmationCode", confirmationCode)
+                .queryParam("customerName", customerName)
                 .when()
                 .delete("/api/reservations/{id}", reservationId)
                 .then()

--- a/src/test/java/com/camping/legacy/AbstractIntegrationTest.java
+++ b/src/test/java/com/camping/legacy/AbstractIntegrationTest.java
@@ -90,6 +90,14 @@ public abstract class AbstractIntegrationTest {
         reservationRepository.save(reservation);
     }
 
+    protected ExtractableResponse<Response> getAvailability(String siteNumber, LocalDate date) {
+        return RestAssured
+                .when()
+                .get("/api/sites/" + siteNumber + "/availability?date=" + date)
+                .then().log().all()
+                .extract();
+    }
+
     protected void assertStatusAndMessage(ExtractableResponse<Response> response, int status, String message) {
         assertThat(response.statusCode()).isEqualTo(status);
         assertThat(response.jsonPath().getString("message")).isEqualTo(message);

--- a/src/test/java/com/camping/legacy/AbstractIntegrationTest.java
+++ b/src/test/java/com/camping/legacy/AbstractIntegrationTest.java
@@ -67,11 +67,12 @@ public abstract class AbstractIntegrationTest {
                 .extract();
     }
 
-    protected ExtractableResponse<Response> cancelReservation(Long reservationId) {
+    protected ExtractableResponse<Response> cancelReservation(Long reservationId, String confirmationCode) {
         return RestAssured.given()
                 .contentType(ContentType.JSON)
+                .queryParam("confirmationCode", confirmationCode)
                 .when()
-                .delete("/api/reservations/" + reservationId)
+                .delete("/api/reservations/{id}", reservationId)
                 .then()
                 .extract();
     }

--- a/src/test/java/com/camping/legacy/AbstractIntegrationTest.java
+++ b/src/test/java/com/camping/legacy/AbstractIntegrationTest.java
@@ -1,0 +1,97 @@
+package com.camping.legacy;
+
+import com.camping.legacy.domain.Campsite;
+import com.camping.legacy.domain.Reservation;
+import com.camping.legacy.repository.CampsiteRepository;
+import com.camping.legacy.repository.ReservationRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+public abstract class AbstractIntegrationTest {
+
+    @Autowired
+    protected CampsiteRepository campsiteRepository;
+
+    @Autowired
+    protected ReservationRepository reservationRepository;
+
+    protected static final String CUSTOMER_NAME = "홍길동";
+    protected static final String PHONE_NUMBER = "010-1234-5678";
+    protected static final String SITE_NUMBER = "A-1";
+
+    protected Campsite site;
+
+    @BeforeEach
+    void setUpBase() {
+        campsiteRepository.deleteAll();
+        reservationRepository.deleteAll();
+
+        site = new Campsite();
+        site.setSiteNumber(SITE_NUMBER);
+        site.setDescription("대형 사이트 - 전기 있음, 화장실 인근");
+        site.setMaxPeople(6);
+        campsiteRepository.save(site);
+    }
+
+    protected Map<String, String> createReservationMap(String customerName, LocalDate start, LocalDate end,
+                                                       String siteNumber, String phone) {
+        return Map.of(
+                "customerName", customerName,
+                "startDate", start.toString(),
+                "endDate", end.toString(),
+                "siteNumber", siteNumber,
+                "phoneNumber", phone
+        );
+    }
+
+    protected ExtractableResponse<Response> postReservation(Map<String, String> reservation) {
+        return RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body(reservation)
+                .when()
+                .post("/api/reservations")
+                .then()
+                .extract();
+    }
+
+    protected ExtractableResponse<Response> cancelReservation(Long reservationId) {
+        return RestAssured.given()
+                .contentType(ContentType.JSON)
+                .when()
+                .delete("/api/reservations/" + reservationId)
+                .then()
+                .extract();
+    }
+
+    protected void saveReservation(String customerName, LocalDate start, LocalDate end, Campsite campsite) {
+        Reservation reservation = new Reservation();
+        reservation.setCustomerName(customerName);
+        reservation.setStartDate(start);
+        reservation.setEndDate(end);
+        reservation.setReservationDate(LocalDate.now().plusDays(7));
+        reservation.setCampsite(campsite);
+        reservation.setPhoneNumber(PHONE_NUMBER);
+        reservation.setStatus("CONFIRMED");
+        reservation.setConfirmationCode("ABC123");
+        reservation.setCreatedAt(LocalDateTime.now());
+        reservationRepository.save(reservation);
+    }
+
+    protected void assertStatusAndMessage(ExtractableResponse<Response> response, int status, String message) {
+        assertThat(response.statusCode()).isEqualTo(status);
+        assertThat(response.jsonPath().getString("message")).isEqualTo(message);
+    }
+}

--- a/src/test/java/com/camping/legacy/ReservationTest.java
+++ b/src/test/java/com/camping/legacy/ReservationTest.java
@@ -1,22 +1,15 @@
 package com.camping.legacy;
 
-import com.camping.legacy.domain.Campsite;
-import com.camping.legacy.domain.Reservation;
-import com.camping.legacy.repository.CampsiteRepository;
-import com.camping.legacy.repository.ReservationRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -25,82 +18,7 @@ import java.util.concurrent.CountDownLatch;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-public class ReservationTest {
-
-    private static final String CUSTOMER_NAME = "홍길동";
-    private static final String PHONE_NUMBER = "010-1234-5678";
-    private static final String SITE_NUMBER = "A-1";
-
-    private LocalDate endDate;
-    private Campsite site;
-
-    @Autowired
-    private CampsiteRepository campsiteRepository;
-    @Autowired
-    private ReservationRepository reservationRepository;
-
-    @BeforeEach
-    void setUp() {
-        campsiteRepository.deleteAll();
-        reservationRepository.deleteAll();
-
-        site = new Campsite();
-        site.setSiteNumber(SITE_NUMBER);
-        site.setDescription("대형 사이트 - 전기 있음, 화장실 인근");
-        site.setMaxPeople(6);
-        campsiteRepository.save(site);
-    }
-
-    private Map<String, String> createReservationMap(String customerName, LocalDate start, LocalDate end,
-                                                     String siteNumber, String phone) {
-        return Map.of(
-                "customerName", customerName,
-                "startDate", start.toString(),
-                "endDate", end.toString(),
-                "siteNumber", siteNumber,
-                "phoneNumber", phone
-        );
-    }
-
-    private ExtractableResponse<Response> postReservation(Map<String, String> reservation) {
-        return RestAssured.given()
-                .log().all()
-                .contentType(ContentType.JSON)
-                .body(reservation)
-                .when()
-                .post("/api/reservations")
-                .then().log().all()
-                .extract();
-    }
-
-    private ExtractableResponse<Response> cancelReservation(Long reservationId) {
-        return RestAssured.given()
-                .log().all()
-                .contentType(ContentType.JSON)
-                .when()
-                .delete("/api/reservations/" + reservationId)
-                .then().log().all()
-                .extract();
-    }
-
-    private void saveReservation(String customerName, LocalDate start, LocalDate end, Campsite campsite) {
-        Reservation reservation = new Reservation();
-        reservation.setCustomerName(customerName);
-        reservation.setStartDate(start);
-        reservation.setEndDate(end);
-        reservation.setReservationDate(LocalDate.now().plusDays(7));
-        reservation.setCampsite(campsite);
-        reservation.setPhoneNumber(PHONE_NUMBER);
-        reservation.setStatus("CONFIRMED");
-        reservation.setConfirmationCode("ABC123");
-        reservation.setCreatedAt(LocalDateTime.now());
-        reservationRepository.save(reservation);
-    }
-
-    private void assertStatusAndMessage(ExtractableResponse<Response> response, int status, String message) {
-        assertThat(response.statusCode()).isEqualTo(status);
-        assertThat(response.jsonPath().getString("message")).isEqualTo(message);
-    }
+public class ReservationTest extends AbstractIntegrationTest {
 
     @Test
     @DisplayName("고객이 빈 사이트를 예약할 수 있다")

--- a/src/test/java/com/camping/legacy/ReservationTest.java
+++ b/src/test/java/com/camping/legacy/ReservationTest.java
@@ -162,7 +162,7 @@ public class ReservationTest extends AbstractIntegrationTest {
 
         Map<String, String> reservation = createReservationMap(
                 CUSTOMER_NAME,
-                today,
+                today.plusDays(1),
                 today.plusDays(1),
                 SITE_NUMBER,
                 PHONE_NUMBER
@@ -178,7 +178,7 @@ public class ReservationTest extends AbstractIntegrationTest {
         // Then: 다른 고객이 같은 날짜/사이트로 예약 가능
         Map<String, String> newReservation = createReservationMap(
                 "김철수",
-                today,
+                today.plusDays(1),
                 today.plusDays(1),
                 SITE_NUMBER,
                 "010-0000-0000"

--- a/src/test/java/com/camping/legacy/ReservationTest.java
+++ b/src/test/java/com/camping/legacy/ReservationTest.java
@@ -143,13 +143,15 @@ public class ReservationTest extends AbstractIntegrationTest {
                 PHONE_NUMBER
         );
 
-        Long reservationId = postReservation(reservation).jsonPath().getLong("id");
+        ExtractableResponse<Response> reservationResponse = postReservation(reservation);
+        Long reservationId = reservationResponse.jsonPath().getLong("id");
+        String confirmationCode = reservationResponse.jsonPath().getString("confirmationCode");
 
         // When: 취소 요청
-        ExtractableResponse<Response> canceledResponse = cancelReservation(reservationId);
+        ExtractableResponse<Response> canceledResponse = cancelReservation(reservationId, confirmationCode);
 
         // Then: 당일 취소는 환불 불가
-        assertStatusAndMessage(canceledResponse, HttpStatus.BAD_REQUEST.value(), "CANCELLED_SAME_DAY");
+        assertStatusAndMessage(canceledResponse, HttpStatus.OK.value(), "CANCELLED_SAME_DAY");
     }
 
     @Test
@@ -165,10 +167,12 @@ public class ReservationTest extends AbstractIntegrationTest {
                 PHONE_NUMBER
         );
 
-        Long reservationId = postReservation(reservation).jsonPath().getLong("id");
+        ExtractableResponse<Response> reservationResponse = postReservation(reservation);
+        Long reservationId = reservationResponse.jsonPath().getLong("id");
+        String confirmationCode = reservationResponse.jsonPath().getString("confirmationCode");
 
         // When: 예약 취소
-        cancelReservation(reservationId);
+        cancelReservation(reservationId, confirmationCode);
 
         // Then: 다른 고객이 같은 날짜/사이트로 예약 가능
         Map<String, String> newReservation = createReservationMap(

--- a/src/test/java/com/camping/legacy/ReservationTest.java
+++ b/src/test/java/com/camping/legacy/ReservationTest.java
@@ -151,7 +151,8 @@ public class ReservationTest extends AbstractIntegrationTest {
         ExtractableResponse<Response> canceledResponse = cancelReservation(reservationId, confirmationCode);
 
         // Then: 당일 취소는 환불 불가
-        assertStatusAndMessage(canceledResponse, HttpStatus.OK.value(), "CANCELLED_SAME_DAY");
+        assertThat(canceledResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertStatusAndMessage(canceledResponse, HttpStatus.OK.value(), "예약이 취소되었습니다. 예약 당일 취소는 환불이 불가능 합니다.");
     }
 
     @Test

--- a/src/test/java/com/camping/legacy/SiteTest.java
+++ b/src/test/java/com/camping/legacy/SiteTest.java
@@ -1,64 +1,30 @@
 package com.camping.legacy;
 
-import com.camping.legacy.domain.Campsite;
-import com.camping.legacy.domain.Reservation;
-import com.camping.legacy.repository.CampsiteRepository;
-import com.camping.legacy.repository.ReservationRepository;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-public class SiteTest {
-    private LocalDate startDate;
-    private LocalDate endDate;
-    private Campsite site;
-    @Autowired
-    private CampsiteRepository campsiteRepository;
-    @Autowired
-    private ReservationRepository reservationRepository;
-
-    @BeforeEach
-    void setUp() {
-        startDate = LocalDate.now().plusDays(1);  // 내일
-        endDate = startDate.plusDays(3);
-
-        campsiteRepository.deleteAll();
-
-        site = new Campsite();
-        site.setSiteNumber("A-1");
-        site.setDescription("대형 사이트 - 전기 있음, 화장실 인근");
-        site.setMaxPeople(6);
-        campsiteRepository.save(site);
-
-        reservationRepository.deleteAll();
-    }
+public class SiteTest extends AbstractIntegrationTest {
 
     @Test
     @DisplayName("고객이 원하는 날짜에 사이트가 예약 가능한지 확인한다.")
     void 예약_가능_확인() {
-        // Given: 고객이 특정 날짜와 사이트 A-1을 선택했을 때
-        String siteNumber = "A-1";
-        LocalDate reservationDate = startDate;
+        // Given
+        String siteNumber = SITE_NUMBER;
+        LocalDate reservationDate = LocalDate.now().plusDays(1);
 
-        // When: 가용성 조회를 하면
-        ExtractableResponse<Response> response = RestAssured
-                .when()
-                .get("/api/sites/"+siteNumber+"/availability?date="+reservationDate)
-                .then().log().all()
-                .extract();
+        // When
+        ExtractableResponse<Response> response = getAvailability(siteNumber, reservationDate);
 
-        // Then: 시스템은 예약 가능 상태를 보여준다.
+        // Then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         assertThat(response.jsonPath().getString("siteNumber")).isEqualTo(siteNumber);
         assertThat(response.jsonPath().getString("date")).isEqualTo(reservationDate.toString());
@@ -68,33 +34,25 @@ public class SiteTest {
     @Test
     @DisplayName("예약된 날짜와 사이트는 예약 불가능을 확인한다.")
     void 예약_불가_확인() {
-        // Given: 고객이 이미 예약된 날짜와 사이트를 선택했을 때
-        Reservation reservation = new Reservation();
-        reservation.setCustomerName("홍길동");
-        reservation.setStartDate(startDate);
-        reservation.setEndDate(endDate);
-        reservation.setReservationDate(LocalDate.now().plusDays(7));
-        reservation.setCampsite(site);  // Campsite 엔티티 연결
-        reservation.setPhoneNumber("010-1234-5678");
-        reservation.setStatus("CONFIRMED");
-        reservation.setConfirmationCode("ABC123");
-        reservation.setCreatedAt(LocalDateTime.now());
+        // Given: API로 사전 예약 생성
+        Map<String, String> reservation = createReservationMap(
+                CUSTOMER_NAME,
+                LocalDate.now().plusDays(1),
+                LocalDate.now().plusDays(3),
+                SITE_NUMBER,
+                PHONE_NUMBER
+        );
+        postReservation(reservation);
 
-        reservationRepository.save(reservation);
-        String siteNumber = reservation.getCampsite().getSiteNumber();
-        LocalDate reservationDate = reservation.getStartDate();
+        LocalDate reservedDate = LocalDate.now().plusDays(1);
 
-        // When: 가용성 조회를 하면
-        ExtractableResponse<Response> response = RestAssured
-                .when()
-                .get("/api/sites/"+siteNumber+"/availability?date="+reservationDate)
-                .then().log().all()
-                .extract();
+        // When
+        ExtractableResponse<Response> response = getAvailability(SITE_NUMBER, reservedDate);
 
-        // Then: 시스템은 예약 불가 상태를 보여준다.
+        // Then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.jsonPath().getString("siteNumber")).isEqualTo(siteNumber);
-        assertThat(response.jsonPath().getString("date")).isEqualTo(reservationDate.toString());
+        assertThat(response.jsonPath().getString("siteNumber")).isEqualTo(SITE_NUMBER);
+        assertThat(response.jsonPath().getString("date")).isEqualTo(reservedDate.toString());
         assertThat(response.jsonPath().getBoolean("available")).isFalse();
     }
 }


### PR DESCRIPTION
안녕하세요 3단계 리뷰 요청드립니다😊

동시성 처리 관련해서 고민한 부분을 공유드립니다.
  1. 처음에는 existsByCampsiteAndStartDateLessThanEqualAndEndDateGreaterThanEqual 조회 단계에만 락을 걸어봤습니다.
  2. 하지만 조회 후 save 사이에 다른 트랜잭션이 동시에 들어오면, 같은 기간 예약이 중복으로 등록될 수 있다는 문제가 있을거라는 생각이 들었습니다.
  3. 이걸 해결하기 위해 findBySiteNumber에 비관적 락을 적용했습니다.
  4. 이렇게 하면 동일 사이트에 대한 요청은 순차적으로 처리되고, 다른 사이트는 병렬로 처리 가능하여 성능과 동시성 문제를 동시에 잡을 수 있다고 생각했습니다.

혹시 제 논리나 접근 방식에 개선할 점이 있을까요?

그리고, 본인확인 후 예약 취소 테스트에서는 일단 이름으로만 확인을 했는데 괜찮은가요?