### PR TITLE
3단계 - 버그 수정과 테스트 보강

### DIFF
--- a/src/main/java/com/camping/legacy/common/ClockProvider.java
+++ b/src/main/java/com/camping/legacy/common/ClockProvider.java
@@ -1,0 +1,7 @@
+package com.camping.legacy.common;
+
+import java.time.LocalDate;
+
+public interface ClockProvider {
+    LocalDate now();
+}

--- a/src/main/java/com/camping/legacy/common/FixedClockProvider.java
+++ b/src/main/java/com/camping/legacy/common/FixedClockProvider.java
@@ -1,0 +1,17 @@
+package com.camping.legacy.common;
+
+import java.time.LocalDate;
+
+public class FixedClockProvider implements ClockProvider {
+    
+    private final LocalDate fixedDate;
+    
+    public FixedClockProvider(LocalDate fixedDate) {
+        this.fixedDate = fixedDate;
+    }
+    
+    @Override
+    public LocalDate now() {
+        return fixedDate;
+    }
+}

--- a/src/main/java/com/camping/legacy/common/SystemClockProvider.java
+++ b/src/main/java/com/camping/legacy/common/SystemClockProvider.java
@@ -1,0 +1,11 @@
+package com.camping.legacy.common;
+
+import java.time.LocalDate;
+
+public class SystemClockProvider implements ClockProvider {
+    
+    @Override
+    public LocalDate now() {
+        return LocalDate.now();
+    }
+}

--- a/src/main/java/com/camping/legacy/config/ClockConfiguration.java
+++ b/src/main/java/com/camping/legacy/config/ClockConfiguration.java
@@ -1,0 +1,17 @@
+package com.camping.legacy.config;
+
+import com.camping.legacy.common.ClockProvider;
+import com.camping.legacy.common.SystemClockProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+public class ClockConfiguration {
+    
+    @Bean
+    @Profile("!test")
+    public ClockProvider clockProvider() {
+        return new SystemClockProvider();
+    }
+}

--- a/src/main/java/com/camping/legacy/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/camping/legacy/exception/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.camping.legacy.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<Map<String, String>> handleRuntimeException(RuntimeException e) {
+        Map<String, String> error = new HashMap<>();
+        error.put("message", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+}

--- a/src/main/java/com/camping/legacy/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/camping/legacy/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.camping.legacy.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -15,6 +16,13 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Map<String, String>> handleRuntimeException(RuntimeException e) {
         Map<String, String> error = new HashMap<>();
         error.put("message", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+    
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<Map<String, String>> handleMissingParams(MissingServletRequestParameterException e) {
+        Map<String, String> error = new HashMap<>();
+        error.put("message", "필수 파라미터 '" + e.getParameterName() + "'가 누락되었습니다");
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
     }
 }

--- a/src/main/java/com/camping/legacy/repository/CampsiteRepository.java
+++ b/src/main/java/com/camping/legacy/repository/CampsiteRepository.java
@@ -2,12 +2,20 @@ package com.camping.legacy.repository;
 
 import com.camping.legacy.domain.Campsite;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 
 @Repository
 public interface CampsiteRepository extends JpaRepository<Campsite, Long> {
     
     Optional<Campsite> findBySiteNumber(String siteNumber);
+    
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM Campsite c WHERE c.siteNumber = :siteNumber")
+    Optional<Campsite> findBySiteNumberWithLock(@Param("siteNumber") String siteNumber);
 }

--- a/src/main/java/com/camping/legacy/service/ReservationService.java
+++ b/src/main/java/com/camping/legacy/service/ReservationService.java
@@ -28,7 +28,7 @@ public class ReservationService {
     
     public ReservationResponse createReservation(ReservationRequest request) {
         String siteNumber = request.getSiteNumber();
-        Campsite campsite = campsiteRepository.findBySiteNumber(siteNumber)
+        Campsite campsite = campsiteRepository.findBySiteNumberWithLock(siteNumber)
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 캠핑장입니다."));
         
         LocalDate startDate = request.getStartDate();

--- a/src/main/java/com/camping/legacy/service/ReservationService.java
+++ b/src/main/java/com/camping/legacy/service/ReservationService.java
@@ -1,5 +1,6 @@
 package com.camping.legacy.service;
 
+import com.camping.legacy.common.ClockProvider;
 import com.camping.legacy.domain.Campsite;
 import com.camping.legacy.domain.Reservation;
 import com.camping.legacy.dto.ReservationRequest;
@@ -11,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -23,6 +23,7 @@ public class ReservationService {
     
     private final ReservationRepository reservationRepository;
     private final CampsiteRepository campsiteRepository;
+    private final ClockProvider clockProvider;
     
     private static final int MAX_RESERVATION_DAYS = 30;
     
@@ -42,7 +43,7 @@ public class ReservationService {
             throw new RuntimeException("종료일이 시작일보다 이전일 수 없습니다.");
         }
         
-        if (startDate.isAfter(LocalDate.now().plusDays(MAX_RESERVATION_DAYS))) {
+        if (startDate.isAfter(clockProvider.now().plusDays(MAX_RESERVATION_DAYS))) {
             throw new RuntimeException("예약은 30일 이내에만 가능합니다");
         }
         
@@ -111,7 +112,7 @@ public class ReservationService {
             throw new RuntimeException("확인 코드가 일치하지 않습니다.");
         }
         
-        LocalDate today = LocalDate.now();
+        LocalDate today = clockProvider.now();
         if (reservation.getStartDate().equals(today)) {
             reservation.setStatus("CANCELLED_SAME_DAY");
         } else {

--- a/src/main/java/com/camping/legacy/service/ReservationService.java
+++ b/src/main/java/com/camping/legacy/service/ReservationService.java
@@ -42,6 +42,10 @@ public class ReservationService {
             throw new RuntimeException("종료일이 시작일보다 이전일 수 없습니다.");
         }
         
+        if (startDate.isAfter(LocalDate.now().plusDays(MAX_RESERVATION_DAYS))) {
+            throw new RuntimeException("예약은 30일 이내에만 가능합니다");
+        }
+        
         if (request.getCustomerName() == null || request.getCustomerName().trim().isEmpty()) {
             throw new RuntimeException("예약자 이름을 입력해주세요.");
         }

--- a/src/test/java/com/camping/legacy/acceptance/BaseAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/acceptance/BaseAcceptanceTest.java
@@ -1,13 +1,19 @@
 package com.camping.legacy.acceptance;
 
+import com.camping.legacy.common.ClockProvider;
+import com.camping.legacy.config.TestClockConfiguration;
 import com.camping.legacy.repository.ReservationRepository;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(TestClockConfiguration.class)
+@ActiveProfiles("test")
 class BaseAcceptanceTest {
     
     @LocalServerPort
@@ -15,6 +21,9 @@ class BaseAcceptanceTest {
     
     @Autowired
     protected ReservationRepository reservationRepository;
+    
+    @Autowired
+    protected ClockProvider clockProvider;
     
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/camping/legacy/acceptance/ReservationCreationAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/acceptance/ReservationCreationAcceptanceTest.java
@@ -249,9 +249,48 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
         }
 
         // then - 모든 예약이 성공해야 한다
-        for (int i = 0; i < responses.size(); i++) {
-            ExtractableResponse<Response> response = responses.get(i);
+        for (ExtractableResponse<Response> response : responses) {
             assertThat(response.statusCode()).isEqualTo(CREATED.value());
         }
+    }
+
+    @Test
+    void 고객명이_null인_경우_예약_실패() {
+        // when - 고객명이 null인 예약을 시도하면
+        Map<String, Object> invalidReservation = new ReservationTestDataBuilder()
+                .withName(null)
+                .build();
+
+        ExtractableResponse<Response> response = given()
+                .contentType("application/json")
+                .body(invalidReservation)
+                .when()
+                .post("/api/reservations")
+                .then()
+                .extract();
+
+        // then - 예약이 실패한다
+        assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
+        assertThat(response.jsonPath().getString("message")).isEqualTo("예약자 이름을 입력해주세요.");
+    }
+
+    @Test
+    void 고객명이_빈_문자열인_경우_예약_실패() {
+        // when - 고객명이 빈 문자열인 예약을 시도하면
+        Map<String, Object> invalidReservation = new ReservationTestDataBuilder()
+                .withName("")
+                .build();
+
+        ExtractableResponse<Response> response = given()
+                .contentType("application/json")
+                .body(invalidReservation)
+                .when()
+                .post("/api/reservations")
+                .then()
+                .extract();
+
+        // then - 예약이 실패한다
+        assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
+        assertThat(response.jsonPath().getString("message")).isEqualTo("예약자 이름을 입력해주세요.");
     }
 }

--- a/src/test/java/com/camping/legacy/acceptance/ReservationCreationAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/acceptance/ReservationCreationAcceptanceTest.java
@@ -1,10 +1,10 @@
 package com.camping.legacy.acceptance;
 
-import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.CONFLICT;
 
+import com.camping.legacy.acceptance.support.ReservationApiHelper;
 import com.camping.legacy.acceptance.support.ReservationTestDataBuilder;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -32,13 +32,7 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
                 .withDates(startDate, endDate)
                 .build();
 
-        ExtractableResponse<Response> response = given()
-                .contentType("application/json")
-                .body(reservationRequest)
-                .when()
-                    .post("/api/reservations")
-                .then()
-                    .extract();
+        ExtractableResponse<Response> response = ReservationApiHelper.createReservation(reservationRequest);
 
         // then - 예약이 완료되고
         // and - 6자리 예약 확인 번호를 받는다
@@ -65,13 +59,7 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
                             .withDates(startDate, endDate)
                             .build();
 
-                    ExtractableResponse<Response> response = given()
-                            .contentType("application/json")
-                            .body(request)
-                    .when()
-                            .post("/api/reservations")
-                    .then()
-                            .extract();
+                    ExtractableResponse<Response> response = ReservationApiHelper.createReservation(request);
 
                     synchronized (responses) {
                         responses.add(response);
@@ -118,13 +106,7 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
                 .withDates(startDate, endDate)
                 .build();
 
-        given()
-            .contentType("application/json")
-            .body(existingReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .statusCode(CREATED.value());
+        ReservationApiHelper.createReservation(existingReservation);
 
         // when - 고객이 같은 기간으로 B-1 캠핑 구역을 예약하려고 하면
         Map<String, Object> newReservation = new ReservationTestDataBuilder()
@@ -134,13 +116,7 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
             .withPhone("010-8888-8888")
             .build();
 
-        ExtractableResponse<Response> response = given()
-            .contentType("application/json")
-            .body(newReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .extract();
+        ExtractableResponse<Response> response = ReservationApiHelper.createReservation(newReservation);
 
         // then - "해당 기간에 이미 예약이 존재합니다"라는 안내 메시지가 나타난다
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
@@ -155,13 +131,7 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
             .withValidFutureReservation()
             .build();
 
-        ExtractableResponse<Response> response = given()
-            .contentType("application/json")
-            .body(singleReservation)
-            .when()
-               .post("/api/reservations")
-            .then()
-                .extract();
+        ExtractableResponse<Response> response = ReservationApiHelper.createReservation(singleReservation);
 
         // then - 예약이 성공한다
         assertThat(response.statusCode()).isEqualTo(CREATED.value());
@@ -175,13 +145,7 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
             .withValidFutureReservation()
             .build();
 
-        ExtractableResponse<Response> response = given()
-            .contentType("application/json")
-            .body(reservationForCode)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .extract();
+        ExtractableResponse<Response> response = ReservationApiHelper.createReservation(reservationForCode);
 
         // then - 확인 코드는 영문자 6자리여야 한다
         assertThat(response.statusCode()).isEqualTo(CREATED.value());
@@ -201,13 +165,7 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
                     .withValidFutureReservation()
                     .build();
 
-            ExtractableResponse<Response> response = given()
-                    .contentType("application/json")
-                    .body(reservation)
-                    .when()
-                        .post("/api/reservations")
-                    .then()
-                        .extract();
+            ExtractableResponse<Response> response = ReservationApiHelper.createReservation(reservation);
 
             responses.add(response);
         }
@@ -226,13 +184,7 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
             .withValidFutureReservation()
             .build();
 
-        ExtractableResponse<Response> response = given()
-            .contentType("application/json")
-            .body(invalidReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .extract();
+        ExtractableResponse<Response> response = ReservationApiHelper.createReservation(invalidReservation);
 
         // then - "예약자 이름을 입력해주세요." 라는 안내 메세지가 나타난다.
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
@@ -247,13 +199,7 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
             .withValidFutureReservation()
             .build();
 
-        ExtractableResponse<Response> response = given()
-            .contentType("application/json")
-            .body(invalidReservation)
-            .when()
-            .post("/api/reservations")
-            .then()
-            .extract();
+        ExtractableResponse<Response> response = ReservationApiHelper.createReservation(invalidReservation);
 
         // then - "예약자 이름을 입력해주세요." 라는 안내 메세지가 나타난다.
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());

--- a/src/test/java/com/camping/legacy/acceptance/ReservationCreationAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/acceptance/ReservationCreationAcceptanceTest.java
@@ -5,11 +5,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.CREATED;
 
+import com.camping.legacy.acceptance.support.ReservationTestDataBuilder;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -27,12 +27,12 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
         LocalDate startDate = LocalDate.of(currentYear, 12, 25);
         LocalDate endDate = LocalDate.of(currentYear, 12, 27);
 
-        Map<String, Object> reservationRequest = new HashMap<>();
-        reservationRequest.put("siteNumber", "A-2");
-        reservationRequest.put("startDate", startDate.toString());
-        reservationRequest.put("endDate", endDate.toString());
-        reservationRequest.put("customerName", "김테스트");
-        reservationRequest.put("phoneNumber", "010-1234-5678");
+        Map<String, Object> reservationRequest = new ReservationTestDataBuilder()
+                .withSiteNumber("A-2")
+                .withDates(startDate, endDate)
+                .withName("김테스트")
+                .withPhone("010-1234-5678")
+                .build();
 
         ExtractableResponse<Response> response = given()
                 .contentType("application/json")
@@ -59,13 +59,13 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
         LocalDate startDate = LocalDate.of(currentYear, 12, 25);
         LocalDate endDate = LocalDate.of(currentYear, 12, 27);
         
-        Map<String, Object> reservationRequest = new HashMap<>();
-        reservationRequest.put("siteNumber", "A-1");
-        reservationRequest.put("startDate", startDate.toString());
-        reservationRequest.put("endDate", endDate.toString());
-        reservationRequest.put("customerName", "동시테스트");
-        reservationRequest.put("phoneNumber", "010-1111-1111");
-        
+        Map<String, Object> reservationRequest = new ReservationTestDataBuilder()
+                .withSiteNumber("A-1")
+                .withDates(startDate, endDate)
+                .withName("동시테스트")
+                .withPhone("010-1111-1111")
+                .build();
+
         ExecutorService executorService = Executors.newFixedThreadPool(10);
         CountDownLatch latch = new CountDownLatch(10);
         List<ExtractableResponse<Response>> responses = new ArrayList<>();
@@ -74,9 +74,12 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
             final int customerIndex = i;
             executorService.execute(() -> {
                 try {
-                    Map<String, Object> request = new HashMap<>(reservationRequest);
-                    request.put("customerName", "동시테스트" + customerIndex);
-                    request.put("phoneNumber", "010-1111-111" + customerIndex);
+                    Map<String, Object> request = new ReservationTestDataBuilder()
+                            .withSiteNumber("A-1")
+                            .withDates(startDate, endDate)
+                            .withName("동시테스트" + customerIndex)
+                            .withPhone("010-1111-111" + customerIndex)
+                            .build();
                     
                     ExtractableResponse<Response> response = given()
                             .contentType("application/json")
@@ -126,12 +129,12 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
         LocalDate endDate = LocalDate.of(currentYear, 12, 27);
 
         // 사전 예약 생성
-        Map<String, Object> existingReservation = new HashMap<>();
-        existingReservation.put("siteNumber", "B-1");
-        existingReservation.put("startDate", startDate.toString());
-        existingReservation.put("endDate", endDate.toString());
-        existingReservation.put("customerName", "기존고객");
-        existingReservation.put("phoneNumber", "010-9999-9999");
+        Map<String, Object> existingReservation = new ReservationTestDataBuilder()
+                .withSiteNumber("B-1")
+                .withDates(startDate, endDate)
+                .withName("기존고객")
+                .withPhone("010-9999-9999")
+                .build();
         
         given()
                 .contentType("application/json")
@@ -142,12 +145,12 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
                 .statusCode(CREATED.value());
         
         // 동일한 기간으로 새로운 예약 시도
-        Map<String, Object> newReservation = new HashMap<>();
-        newReservation.put("siteNumber", "B-1");
-        newReservation.put("startDate", startDate.toString());
-        newReservation.put("endDate", endDate.toString());
-        newReservation.put("customerName", "새로운고객");
-        newReservation.put("phoneNumber", "010-8888-8888");
+        Map<String, Object> newReservation = new ReservationTestDataBuilder()
+                .withSiteNumber("B-1")
+                .withDates(startDate, endDate)
+                .withName("새로운고객")
+                .withPhone("010-8888-8888")
+                .build();
         
         // when - 고객이 같은 기간으로 B-1 캠핑 구역을 예약하려고 하면
         ExtractableResponse<Response> response = given()

--- a/src/test/java/com/camping/legacy/acceptance/ReservationCreationAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/acceptance/ReservationCreationAcceptanceTest.java
@@ -2,8 +2,8 @@ package com.camping.legacy.acceptance;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.CONFLICT;
 
 import com.camping.legacy.acceptance.support.ReservationTestDataBuilder;
 import io.restassured.response.ExtractableResponse;

--- a/src/test/java/com/camping/legacy/acceptance/ReservationCreationAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/acceptance/ReservationCreationAcceptanceTest.java
@@ -152,6 +152,7 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
         // when - B-8 캠핑 구역을 1명의 고객이 예약을 시도하면
         Map<String, Object> singleReservation = new ReservationTestDataBuilder()
             .withSiteNumber("B-8")
+            .withValidFutureReservation()
             .build();
 
         ExtractableResponse<Response> response = given()
@@ -171,6 +172,7 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
         // when - B-9 캠핑 구역에 예약을 생성하면
         Map<String, Object> reservationForCode = new ReservationTestDataBuilder()
             .withSiteNumber("B-9")
+            .withValidFutureReservation()
             .build();
 
         ExtractableResponse<Response> response = given()
@@ -196,6 +198,7 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
         for (int i = 1; i <= 5; i++) {
             Map<String, Object> reservation = new ReservationTestDataBuilder()
                     .withSiteNumber("B-1" + i) // B-11, B-12, B-13, B-14, B-15
+                    .withValidFutureReservation()
                     .build();
 
             ExtractableResponse<Response> response = given()
@@ -220,6 +223,7 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
         // when - 고객명이 null인 예약을 시도하면
         Map<String, Object> invalidReservation = new ReservationTestDataBuilder()
             .withName(null)
+            .withValidFutureReservation()
             .build();
 
         ExtractableResponse<Response> response = given()
@@ -240,6 +244,7 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
         // when - 고객명이 빈 문자열인 예약을 시도하면
         Map<String, Object> invalidReservation = new ReservationTestDataBuilder()
             .withName("")
+            .withValidFutureReservation()
             .build();
 
         ExtractableResponse<Response> response = given()

--- a/src/test/java/com/camping/legacy/acceptance/ReservationCreationAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/acceptance/ReservationCreationAcceptanceTest.java
@@ -58,7 +58,7 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
         int currentYear = LocalDate.now().getYear();
         LocalDate startDate = LocalDate.of(currentYear, 12, 25);
         LocalDate endDate = LocalDate.of(currentYear, 12, 27);
-        
+
         Map<String, Object> reservationRequest = new ReservationTestDataBuilder()
                 .withSiteNumber("A-1")
                 .withDates(startDate, endDate)
@@ -69,7 +69,7 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
         ExecutorService executorService = Executors.newFixedThreadPool(10);
         CountDownLatch latch = new CountDownLatch(10);
         List<ExtractableResponse<Response>> responses = new ArrayList<>();
-        
+
         for (int i = 0; i < 10; i++) {
             final int customerIndex = i;
             executorService.execute(() -> {
@@ -80,7 +80,7 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
                             .withName("동시테스트" + customerIndex)
                             .withPhone("010-1111-111" + customerIndex)
                             .build();
-                    
+
                     ExtractableResponse<Response> response = given()
                             .contentType("application/json")
                             .body(request)
@@ -88,7 +88,7 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
                             .post("/api/reservations")
                     .then()
                             .extract();
-                    
+
                     synchronized (responses) {
                         responses.add(response);
                     }
@@ -97,25 +97,25 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
                 }
             });
         }
-        
+
         try {
             latch.await();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
         executorService.shutdown();
-        
+
         // then - 한 명만 예약에 성공하고 나머지 9명은 예약할 수 없다
         long successCount = responses.stream()
                 .mapToInt(ExtractableResponse::statusCode)
                 .filter(status -> status == CREATED.value())
                 .count();
-        
+
         long conflictCount = responses.stream()
                 .mapToInt(ExtractableResponse::statusCode)
                 .filter(status -> status == CONFLICT.value())
                 .count();
-        
+
         assertThat(successCount).isEqualTo(1);
         assertThat(conflictCount).isEqualTo(9);
         assertThat(responses).hasSize(10);
@@ -135,7 +135,7 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
                 .withName("기존고객")
                 .withPhone("010-9999-9999")
                 .build();
-        
+
         given()
                 .contentType("application/json")
                 .body(existingReservation)
@@ -143,7 +143,7 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
                 .post("/api/reservations")
         .then()
                 .statusCode(CREATED.value());
-        
+
         // 동일한 기간으로 새로운 예약 시도
         Map<String, Object> newReservation = new ReservationTestDataBuilder()
                 .withSiteNumber("B-1")
@@ -151,7 +151,7 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
                 .withName("새로운고객")
                 .withPhone("010-8888-8888")
                 .build();
-        
+
         // when - 고객이 같은 기간으로 B-1 캠핑 구역을 예약하려고 하면
         ExtractableResponse<Response> response = given()
                 .contentType("application/json")
@@ -160,9 +160,98 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
                 .post("/api/reservations")
         .then()
                 .extract();
-        
+
         // then - "해당 기간에 이미 예약이 존재합니다"라는 안내 메시지가 나타난다
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
         assertThat(response.jsonPath().getString("message")).isEqualTo("해당 기간에 이미 예약이 존재합니다.");
+    }
+
+    @Test
+    void 단독_예약_시도_성공() {
+        // when - B-8 캠핑 구역을 1명의 고객이 예약을 시도하면
+        LocalDate startDate = LocalDate.now().plusDays(5);
+        LocalDate endDate = LocalDate.now().plusDays(7);
+
+        Map<String, Object> singleReservation = new ReservationTestDataBuilder()
+                .withSiteNumber("B-8")
+                .withDates(startDate, endDate)
+                .withName("단독예약고객")
+                .withPhone("010-1000-0001")
+                .build();
+
+        ExtractableResponse<Response> response = given()
+                .contentType("application/json")
+                .body(singleReservation)
+                .when()
+                .post("/api/reservations")
+                .then()
+                .extract();
+
+        // then - 동시성 문제 없이 성공한다
+        assertThat(response.statusCode()).isEqualTo(CREATED.value());
+        assertThat(response.jsonPath().getString("customerName")).isEqualTo("단독예약고객");
+        assertThat(response.jsonPath().getString("confirmationCode")).hasSize(6);
+    }
+
+    @Test
+    void 확인_코드_6자리_정확성_검증() {
+        // when - B-9 캠핑 구역에 예약을 생성하면
+        LocalDate startDate = LocalDate.now().plusDays(8);
+        LocalDate endDate = LocalDate.now().plusDays(10);
+
+        Map<String, Object> reservationForCode = new ReservationTestDataBuilder()
+                .withSiteNumber("B-9")
+                .withDates(startDate, endDate)
+                .withName("확인코드검증고객")
+                .withPhone("010-2000-0001")
+                .build();
+
+        ExtractableResponse<Response> response = given()
+                .contentType("application/json")
+                .body(reservationForCode)
+                .when()
+                .post("/api/reservations")
+                .then()
+                .extract();
+
+        // then - 확인 코드는 영문자 6자리여야 한다
+        assertThat(response.statusCode()).isEqualTo(CREATED.value());
+        String confirmationCode = response.jsonPath().getString("confirmationCode");
+        assertThat(confirmationCode).hasSize(6);
+        assertThat(confirmationCode).matches("[A-Z0-9]{6}"); // 영문 대문자와 숫자만
+    }
+
+    @Test
+    void 다중_예약_생성_독립성_검증() {
+        // when - 5개의 서로 다른 캠핑 구역을 연속으로 예약하면
+        LocalDate startDate = LocalDate.now().plusDays(6);
+        LocalDate endDate = LocalDate.now().plusDays(8);
+
+        List<ExtractableResponse<Response>> responses = new ArrayList<>();
+
+        for (int i = 1; i <= 5; i++) {
+            Map<String, Object> reservation = new ReservationTestDataBuilder()
+                    .withSiteNumber("B-1" + i) // B-11, B-12, B-13, B-14, B-15
+                    .withDates(startDate, endDate)
+                    .withName("다중예약고객" + i)
+                    .withPhone("010-3000-000" + i)
+                    .build();
+
+            ExtractableResponse<Response> response = given()
+                    .contentType("application/json")
+                    .body(reservation)
+                    .when()
+                        .post("/api/reservations")
+                    .then()
+                        .extract();
+
+            responses.add(response);
+        }
+
+        // then - 모든 예약이 성공해야 한다
+        for (int i = 0; i < responses.size(); i++) {
+            ExtractableResponse<Response> response = responses.get(i);
+            assertThat(response.statusCode()).isEqualTo(CREATED.value());
+        }
     }
 }

--- a/src/test/java/com/camping/legacy/acceptance/ReservationCreationAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/acceptance/ReservationCreationAcceptanceTest.java
@@ -30,26 +30,20 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
         Map<String, Object> reservationRequest = new ReservationTestDataBuilder()
                 .withSiteNumber("A-2")
                 .withDates(startDate, endDate)
-                .withName("김테스트")
-                .withPhone("010-1234-5678")
                 .build();
 
         ExtractableResponse<Response> response = given()
                 .contentType("application/json")
                 .body(reservationRequest)
                 .when()
-                .post("/api/reservations")
+                    .post("/api/reservations")
                 .then()
-                .extract();
+                    .extract();
 
-        // then - 예약이 완료되고 6자리 예약 확인 번호를 받는다
+        // then - 예약이 완료되고
+        // and - 6자리 예약 확인 번호를 받는다
         assertThat(response.statusCode()).isEqualTo(CREATED.value());
-        assertThat(response.jsonPath().getLong("id")).isNotNull();
         assertThat(response.jsonPath().getString("confirmationCode")).hasSize(6);
-        assertThat(response.jsonPath().getString("customerName")).isEqualTo("김테스트");
-        assertThat(response.jsonPath().getString("siteNumber")).isEqualTo("A-2");
-        assertThat(response.jsonPath().getString("startDate")).isEqualTo(startDate.toString());
-        assertThat(response.jsonPath().getString("endDate")).isEqualTo(endDate.toString());
     }
 
     @Test
@@ -59,26 +53,16 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
         LocalDate startDate = LocalDate.of(currentYear, 12, 25);
         LocalDate endDate = LocalDate.of(currentYear, 12, 27);
 
-        Map<String, Object> reservationRequest = new ReservationTestDataBuilder()
-                .withSiteNumber("A-1")
-                .withDates(startDate, endDate)
-                .withName("동시테스트")
-                .withPhone("010-1111-1111")
-                .build();
-
         ExecutorService executorService = Executors.newFixedThreadPool(10);
         CountDownLatch latch = new CountDownLatch(10);
         List<ExtractableResponse<Response>> responses = new ArrayList<>();
 
         for (int i = 0; i < 10; i++) {
-            final int customerIndex = i;
             executorService.execute(() -> {
                 try {
                     Map<String, Object> request = new ReservationTestDataBuilder()
                             .withSiteNumber("A-1")
                             .withDates(startDate, endDate)
-                            .withName("동시테스트" + customerIndex)
-                            .withPhone("010-1111-111" + customerIndex)
                             .build();
 
                     ExtractableResponse<Response> response = given()
@@ -132,33 +116,30 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
         Map<String, Object> existingReservation = new ReservationTestDataBuilder()
                 .withSiteNumber("B-1")
                 .withDates(startDate, endDate)
-                .withName("기존고객")
-                .withPhone("010-9999-9999")
                 .build();
 
         given()
-                .contentType("application/json")
-                .body(existingReservation)
-        .when()
+            .contentType("application/json")
+            .body(existingReservation)
+            .when()
                 .post("/api/reservations")
-        .then()
+            .then()
                 .statusCode(CREATED.value());
 
-        // 동일한 기간으로 새로운 예약 시도
-        Map<String, Object> newReservation = new ReservationTestDataBuilder()
-                .withSiteNumber("B-1")
-                .withDates(startDate, endDate)
-                .withName("새로운고객")
-                .withPhone("010-8888-8888")
-                .build();
-
         // when - 고객이 같은 기간으로 B-1 캠핑 구역을 예약하려고 하면
+        Map<String, Object> newReservation = new ReservationTestDataBuilder()
+            .withSiteNumber("B-1")
+            .withDates(startDate, endDate)
+            .withName("새로운고객")
+            .withPhone("010-8888-8888")
+            .build();
+
         ExtractableResponse<Response> response = given()
-                .contentType("application/json")
-                .body(newReservation)
-        .when()
+            .contentType("application/json")
+            .body(newReservation)
+            .when()
                 .post("/api/reservations")
-        .then()
+            .then()
                 .extract();
 
         // then - "해당 기간에 이미 예약이 존재합니다"라는 안내 메시지가 나타난다
@@ -169,49 +150,35 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
     @Test
     void 단독_예약_시도_성공() {
         // when - B-8 캠핑 구역을 1명의 고객이 예약을 시도하면
-        LocalDate startDate = LocalDate.now().plusDays(5);
-        LocalDate endDate = LocalDate.now().plusDays(7);
-
         Map<String, Object> singleReservation = new ReservationTestDataBuilder()
-                .withSiteNumber("B-8")
-                .withDates(startDate, endDate)
-                .withName("단독예약고객")
-                .withPhone("010-1000-0001")
-                .build();
+            .withSiteNumber("B-8")
+            .build();
 
         ExtractableResponse<Response> response = given()
-                .contentType("application/json")
-                .body(singleReservation)
-                .when()
-                .post("/api/reservations")
-                .then()
+            .contentType("application/json")
+            .body(singleReservation)
+            .when()
+               .post("/api/reservations")
+            .then()
                 .extract();
 
-        // then - 동시성 문제 없이 성공한다
+        // then - 예약이 성공한다
         assertThat(response.statusCode()).isEqualTo(CREATED.value());
-        assertThat(response.jsonPath().getString("customerName")).isEqualTo("단독예약고객");
-        assertThat(response.jsonPath().getString("confirmationCode")).hasSize(6);
     }
 
     @Test
     void 확인_코드_6자리_정확성_검증() {
         // when - B-9 캠핑 구역에 예약을 생성하면
-        LocalDate startDate = LocalDate.now().plusDays(8);
-        LocalDate endDate = LocalDate.now().plusDays(10);
-
         Map<String, Object> reservationForCode = new ReservationTestDataBuilder()
-                .withSiteNumber("B-9")
-                .withDates(startDate, endDate)
-                .withName("확인코드검증고객")
-                .withPhone("010-2000-0001")
-                .build();
+            .withSiteNumber("B-9")
+            .build();
 
         ExtractableResponse<Response> response = given()
-                .contentType("application/json")
-                .body(reservationForCode)
-                .when()
+            .contentType("application/json")
+            .body(reservationForCode)
+            .when()
                 .post("/api/reservations")
-                .then()
+            .then()
                 .extract();
 
         // then - 확인 코드는 영문자 6자리여야 한다
@@ -224,17 +191,11 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
     @Test
     void 다중_예약_생성_독립성_검증() {
         // when - 5개의 서로 다른 캠핑 구역을 연속으로 예약하면
-        LocalDate startDate = LocalDate.now().plusDays(6);
-        LocalDate endDate = LocalDate.now().plusDays(8);
-
         List<ExtractableResponse<Response>> responses = new ArrayList<>();
 
         for (int i = 1; i <= 5; i++) {
             Map<String, Object> reservation = new ReservationTestDataBuilder()
                     .withSiteNumber("B-1" + i) // B-11, B-12, B-13, B-14, B-15
-                    .withDates(startDate, endDate)
-                    .withName("다중예약고객" + i)
-                    .withPhone("010-3000-000" + i)
                     .build();
 
             ExtractableResponse<Response> response = given()
@@ -258,18 +219,18 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
     void 고객명이_null인_경우_예약_실패() {
         // when - 고객명이 null인 예약을 시도하면
         Map<String, Object> invalidReservation = new ReservationTestDataBuilder()
-                .withName(null)
-                .build();
+            .withName(null)
+            .build();
 
         ExtractableResponse<Response> response = given()
-                .contentType("application/json")
-                .body(invalidReservation)
-                .when()
+            .contentType("application/json")
+            .body(invalidReservation)
+            .when()
                 .post("/api/reservations")
-                .then()
+            .then()
                 .extract();
 
-        // then - 예약이 실패한다
+        // then - "예약자 이름을 입력해주세요." 라는 안내 메세지가 나타난다.
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
         assertThat(response.jsonPath().getString("message")).isEqualTo("예약자 이름을 입력해주세요.");
     }
@@ -278,18 +239,18 @@ class ReservationCreationAcceptanceTest extends BaseAcceptanceTest {
     void 고객명이_빈_문자열인_경우_예약_실패() {
         // when - 고객명이 빈 문자열인 예약을 시도하면
         Map<String, Object> invalidReservation = new ReservationTestDataBuilder()
-                .withName("")
-                .build();
+            .withName("")
+            .build();
 
         ExtractableResponse<Response> response = given()
-                .contentType("application/json")
-                .body(invalidReservation)
-                .when()
-                .post("/api/reservations")
-                .then()
-                .extract();
+            .contentType("application/json")
+            .body(invalidReservation)
+            .when()
+            .post("/api/reservations")
+            .then()
+            .extract();
 
-        // then - 예약이 실패한다
+        // then - "예약자 이름을 입력해주세요." 라는 안내 메세지가 나타난다.
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
         assertThat(response.jsonPath().getString("message")).isEqualTo("예약자 이름을 입력해주세요.");
     }

--- a/src/test/java/com/camping/legacy/acceptance/ReservationStayAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/acceptance/ReservationStayAcceptanceTest.java
@@ -1,10 +1,10 @@
 package com.camping.legacy.acceptance;
 
-import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.CONFLICT;
 
+import com.camping.legacy.acceptance.support.ReservationApiHelper;
 import com.camping.legacy.acceptance.support.ReservationTestDataBuilder;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -34,13 +34,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withDates(conflictDate, conflictDate.plusDays(1))
             .build();
 
-        given()
-            .contentType("application/json")
-            .body(existingReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .statusCode(CREATED.value());
+        ReservationApiHelper.createReservation(existingReservation);
 
         // when - 고객이 12월 20일부터 24일까지 예약하려고 하면
         LocalDate startDate = LocalDate.of(currentYear, 12, 20);
@@ -51,13 +45,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withDates(startDate, endDate)
             .build();
 
-        ExtractableResponse<Response> response = given()
-            .contentType("application/json")
-            .body(newReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .extract();
+        ExtractableResponse<Response> response = ReservationApiHelper.createReservation(newReservation);
 
         // then - "해당 기간에 이미 예약이 존재합니다." 라는 안내 메세지가 나타난다.
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
@@ -76,13 +64,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withDates(startDate, endDate)
             .build();
 
-        ExtractableResponse<Response> response = given()
-            .contentType("application/json")
-            .body(invalidReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .extract();
+        ExtractableResponse<Response> response = ReservationApiHelper.createReservation(invalidReservation);
 
         // then - "종료일이 시작일보다 이전일 수 없습니다." 라는 안내 메세지가 나타난다.
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
@@ -102,13 +84,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withDates(startDate, endDate)
             .build();
 
-        given()
-            .contentType("application/json")
-            .body(existingReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .statusCode(CREATED.value());
+        ReservationApiHelper.createReservation(existingReservation);
 
         // when - 고객이 12월 20일부터 22일까지 예약하려고 하면
         startDate = LocalDate.of(currentYear, 12, 20);
@@ -119,13 +95,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withDates(startDate, endDate)
             .build();
 
-        ExtractableResponse<Response> response = given()
-            .contentType("application/json")
-            .body(overlappingReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .extract();
+        ExtractableResponse<Response> response = ReservationApiHelper.createReservation(overlappingReservation);
 
         // then - "해당 기간에 이미 예약이 존재합니다." 라는 안내 메세지가 나타난다.
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
@@ -143,13 +113,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withDates(startDate, endDate)
             .build();
 
-        ExtractableResponse<Response> response = given()
-            .contentType("application/json")
-            .body(futureReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .extract();
+        ExtractableResponse<Response> response = ReservationApiHelper.createReservation(futureReservation);
 
         // then - "예약은 30일 이내에만 가능합니다"라는 안내 메시지가 나타난다
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
@@ -164,13 +128,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withDateRange(29, 30)
             .build();
 
-        ExtractableResponse<Response> response = given()
-            .contentType("application/json")
-            .body(validReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .extract();
+        ExtractableResponse<Response> response = ReservationApiHelper.createReservation(validReservation);
 
         // then - 예약에 성공한다
         assertThat(response.statusCode()).isEqualTo(CREATED.value());
@@ -184,13 +142,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withDateRange(30, 31)
             .build();
 
-        ExtractableResponse<Response> response = given()
-            .contentType("application/json")
-            .body(validReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .extract();
+        ExtractableResponse<Response> response = ReservationApiHelper.createReservation(validReservation);
 
         // then - 예약에 성공한다
         assertThat(response.statusCode()).isEqualTo(CREATED.value());
@@ -206,13 +158,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withSameDayReservation(sameDate)
             .build();
 
-        ExtractableResponse<Response> response = given()
-            .contentType("application/json")
-            .body(sameDayReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .extract();
+        ExtractableResponse<Response> response = ReservationApiHelper.createReservation(sameDayReservation);
 
         // then - 예약에 성공한다
         assertThat(response.statusCode()).isEqualTo(CREATED.value());
@@ -226,13 +172,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withTodayReservation()
             .build();
 
-        ExtractableResponse<Response> response = given()
-            .contentType("application/json")
-            .body(todayReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .extract();
+        ExtractableResponse<Response> response = ReservationApiHelper.createReservation(todayReservation);
 
         // then - 예약에 성공한다
         assertThat(response.statusCode()).isEqualTo(CREATED.value());
@@ -246,13 +186,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withDateRange(10, 12)
             .build();
 
-        ExtractableResponse<Response> response = given()
-            .contentType("application/json")
-            .body(invalidSiteReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .extract();
+        ExtractableResponse<Response> response = ReservationApiHelper.createReservation(invalidSiteReservation);
 
         // then - "존재하지 않는 캠핑장입니다" 안내 메세지가 나타난다.
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
@@ -278,13 +212,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
                         .withPhone("010-6666-777" + customerIndex)
                         .build();
 
-                    ExtractableResponse<Response> response = given()
-                        .contentType("application/json")
-                        .body(request)
-                        .when()
-                        .post("/api/reservations")
-                        .then()
-                        .extract();
+                    ExtractableResponse<Response> response = ReservationApiHelper.createReservation(request);
 
                     synchronized (responses) {
                         responses.add(response);
@@ -325,13 +253,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withoutDates()
             .build();
 
-        ExtractableResponse<Response> response = given()
-            .contentType("application/json")
-            .body(invalidReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .extract();
+        ExtractableResponse<Response> response = ReservationApiHelper.createReservation(invalidReservation);
 
         // then - "예약 기간을 선택해주세요." 라는 안내 메세지가 나타난다.
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
@@ -350,13 +272,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withDates(existingStart, existingEnd)
             .build();
 
-        given()
-            .contentType("application/json")
-            .body(existingReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .statusCode(CREATED.value());
+        ReservationApiHelper.createReservation(existingReservation);
 
         // when - 동일한 캠핑 구역을 9일부터 14일까지 예약하려고 하면
         LocalDate newStart = LocalDate.of(2025, 12, 9);
@@ -367,13 +283,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withDates(newStart, newEnd)
             .build();
 
-        ExtractableResponse<Response> response = given()
-            .contentType("application/json")
-            .body(newReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .extract();
+        ExtractableResponse<Response> response = ReservationApiHelper.createReservation(newReservation);
 
         // then - "해당 기간에 이미 예약이 존재합니다."라는 안내 메세지가 나타난다.
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
@@ -392,13 +302,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withDates(existingStart, existingEnd)
             .build();
 
-        given()
-            .contentType("application/json")
-            .body(existingReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .statusCode(CREATED.value());
+        ReservationApiHelper.createReservation(existingReservation);
 
         // when - 동일한 캠핑 구역을 16일부터 18일까지 예약하려고 하면
         LocalDate newStart = LocalDate.of(2025, 12, 16);
@@ -409,13 +313,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withDates(newStart, newEnd)
             .build();
 
-        ExtractableResponse<Response> response = given()
-            .contentType("application/json")
-            .body(newReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .extract();
+        ExtractableResponse<Response> response = ReservationApiHelper.createReservation(newReservation);
 
         // then - "해당 기간에 이미 예약이 존재합니다."라는 안내 메세지가 나타난다
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
@@ -433,13 +331,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withDates(existingStart, existingEnd)
             .build();
 
-        given()
-            .contentType("application/json")
-            .body(existingReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .statusCode(CREATED.value());
+        ReservationApiHelper.createReservation(existingReservation);
 
         // when - 동일한 캠핑 구역을 22일부터 25일까지 예약하려고 하면
         LocalDate newStart = LocalDate.of(2025, 12, 22);
@@ -450,13 +342,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withDates(newStart, newEnd)
             .build();
 
-        ExtractableResponse<Response> response = given()
-            .contentType("application/json")
-            .body(newReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .extract();
+        ExtractableResponse<Response> response = ReservationApiHelper.createReservation(newReservation);
 
         // then - "해당 기간에 이미 예약이 존재합니다."라는 안내 메세지가 나타난다.
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
@@ -474,13 +360,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withDates(existingStart, existingEnd)
             .build();
 
-        given()
-            .contentType("application/json")
-            .body(existingReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .statusCode(CREATED.value());
+        ReservationApiHelper.createReservation(existingReservation);
 
         // when - 동일한 캠핑 구역을 23일부터 26일까지 예약하려고 하면
         LocalDate newStart = LocalDate.of(2025, 12, 23);
@@ -491,13 +371,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withDates(newStart, newEnd)
             .build();
 
-        ExtractableResponse<Response> response = given()
-            .contentType("application/json")
-            .body(newReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .extract();
+        ExtractableResponse<Response> response = ReservationApiHelper.createReservation(newReservation);
 
         // then - "해당 기간에 이미 예약이 존재합니다."라는 안내 메세지가 나타난다.
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
@@ -515,13 +389,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withDates(existingStart, existingEnd)
             .build();
 
-        given()
-            .contentType("application/json")
-            .body(existingReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .statusCode(CREATED.value());
+        ReservationApiHelper.createReservation(existingReservation);
 
         // when - 동일한 캠핑 구역을 4일부터 6일까지 예약하려고 하면
         LocalDate newStart = LocalDate.of(2025, 12, 4);
@@ -532,13 +400,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .withDates(newStart, newEnd)
             .build();
 
-        ExtractableResponse<Response> response = given()
-            .contentType("application/json")
-            .body(newReservation)
-            .when()
-                .post("/api/reservations")
-            .then()
-                .extract();
+        ExtractableResponse<Response> response = ReservationApiHelper.createReservation(newReservation);
 
         // then - 예약에 성공한다
         assertThat(response.statusCode()).isEqualTo(CREATED.value());

--- a/src/test/java/com/camping/legacy/acceptance/ReservationStayAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/acceptance/ReservationStayAcceptanceTest.java
@@ -8,6 +8,7 @@ import static org.springframework.http.HttpStatus.CONFLICT;
 import com.camping.legacy.acceptance.support.ReservationTestDataBuilder;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,6 +16,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -28,40 +30,40 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
 
         // 기존 예약 생성
         Map<String, Object> existingReservation = new ReservationTestDataBuilder()
-                .withSiteNumber("A-5")
-                .withDates(conflictDate, conflictDate.plusDays(1))
-                .withName("기존예약고객")
-                .withPhone("010-7777-7777")
-                .build();
-        
+            .withSiteNumber("A-5")
+            .withDates(conflictDate, conflictDate.plusDays(1))
+            .withName("기존예약고객")
+            .withPhone("010-7777-7777")
+            .build();
+
         given()
-                .contentType("application/json")
-                .body(existingReservation)
-        .when()
-                .post("/api/reservations")
-        .then()
-                .statusCode(CREATED.value());
-        
+            .contentType("application/json")
+            .body(existingReservation)
+            .when()
+            .post("/api/reservations")
+            .then()
+            .statusCode(CREATED.value());
+
         // when - 고객이 12월 20일부터 24일까지 예약하려고 하면
         LocalDate startDate = LocalDate.of(currentYear, 12, 20);
         LocalDate endDate = LocalDate.of(currentYear, 12, 24);
-        
+
         Map<String, Object> newReservation = new ReservationTestDataBuilder()
-                .withSiteNumber("A-5")
-                .withDates(startDate, endDate)
-                .withName("연박예약고객")
-                .withPhone("010-6666-6666")
-                .build();
-        
+            .withSiteNumber("A-5")
+            .withDates(startDate, endDate)
+            .withName("연박예약고객")
+            .withPhone("010-6666-6666")
+            .build();
+
         ExtractableResponse<Response> response = given()
-                .contentType("application/json")
-                .body(newReservation)
-        .when()
-                .post("/api/reservations")
-        .then()
-                .extract();
-        
-        // then - 예약할 수 없다
+            .contentType("application/json")
+            .body(newReservation)
+            .when()
+            .post("/api/reservations")
+            .then()
+            .extract();
+
+        // then - 예약에 실패한다
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
         assertThat(response.jsonPath().getString("message")).isEqualTo("해당 기간에 이미 예약이 존재합니다.");
     }
@@ -74,21 +76,21 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         LocalDate endDate = LocalDate.of(currentYear, 12, 8);
 
         Map<String, Object> invalidReservation = new ReservationTestDataBuilder()
-                .withSiteNumber("A-7")
-                .withDates(startDate, endDate)
-                .withName("잘못된날짜고객")
-                .withPhone("010-5555-5555")
-                .build();
+            .withSiteNumber("A-7")
+            .withDates(startDate, endDate)
+            .withName("잘못된날짜고객")
+            .withPhone("010-5555-5555")
+            .build();
 
         ExtractableResponse<Response> response = given()
-                .contentType("application/json")
-                .body(invalidReservation)
-        .when()
-                .post("/api/reservations")
-        .then()
-                .extract();
-        
-        // then - 예약할 수 없다
+            .contentType("application/json")
+            .body(invalidReservation)
+            .when()
+            .post("/api/reservations")
+            .then()
+            .extract();
+
+        // then - 예약에 실패한다
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
         assertThat(response.jsonPath().getString("message")).isEqualTo("종료일이 시작일보다 이전일 수 없습니다.");
     }
@@ -102,38 +104,38 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
 
         // 기존 예약 생성
         Map<String, Object> existingReservation = new ReservationTestDataBuilder()
-                .withSiteNumber("B-2")
-                .withDates(startDate, endDate)
-                .withName("부분충돌고객")
-                .withPhone("010-3333-3333")
-                .build();
+            .withSiteNumber("B-2")
+            .withDates(startDate, endDate)
+            .withName("부분충돌고객")
+            .withPhone("010-3333-3333")
+            .build();
 
         given()
-                .contentType("application/json")
-                .body(existingReservation)
-        .when()
-                .post("/api/reservations")
-        .then()
-                .statusCode(CREATED.value());
+            .contentType("application/json")
+            .body(existingReservation)
+            .when()
+            .post("/api/reservations")
+            .then()
+            .statusCode(CREATED.value());
 
         // when - 고객이 12월 20일부터 22일까지 예약하려고 하면
         startDate = LocalDate.of(currentYear, 12, 20);
         endDate = LocalDate.of(currentYear, 12, 22);
 
         Map<String, Object> overlappingReservation = new ReservationTestDataBuilder()
-                .withSiteNumber("B-2")
-                .withDates(startDate, endDate)
-                .withName("부분예약고객")
-                .withPhone("010-2222-2222")
-                .build();
+            .withSiteNumber("B-2")
+            .withDates(startDate, endDate)
+            .withName("부분예약고객")
+            .withPhone("010-2222-2222")
+            .build();
 
         ExtractableResponse<Response> response = given()
-                .contentType("application/json")
-                .body(overlappingReservation)
-        .when()
-                .post("/api/reservations")
-        .then()
-                .extract();
+            .contentType("application/json")
+            .body(overlappingReservation)
+            .when()
+            .post("/api/reservations")
+            .then()
+            .extract();
 
         // then - 예약할 수 없다
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
@@ -147,19 +149,19 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         LocalDate endDate = clockProvider.now().plusDays(33);
 
         Map<String, Object> futureReservation = new ReservationTestDataBuilder()
-                .withSiteNumber("A-8")
-                .withDates(startDate, endDate)
-                .withName("미래예약고객")
-                .withPhone("010-4444-4444")
-                .build();
+            .withSiteNumber("A-8")
+            .withDates(startDate, endDate)
+            .withName("미래예약고객")
+            .withPhone("010-4444-4444")
+            .build();
 
         ExtractableResponse<Response> response = given()
-                .contentType("application/json")
-                .body(futureReservation)
-                .when()
-                .post("/api/reservations")
-                .then()
-                .extract();
+            .contentType("application/json")
+            .body(futureReservation)
+            .when()
+            .post("/api/reservations")
+            .then()
+            .extract();
 
         // then - "예약은 30일 이내에만 가능합니다"라는 안내 메시지가 나타난다
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
@@ -173,19 +175,19 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         LocalDate endDate = LocalDate.now().plusDays(30);
 
         Map<String, Object> validReservation = new ReservationTestDataBuilder()
-                .withSiteNumber("B-3")
-                .withDates(startDate, endDate)
-                .withName("29일경계고객")
-                .withPhone("010-1111-2222")
-                .build();
+            .withSiteNumber("B-3")
+            .withDates(startDate, endDate)
+            .withName("29일경계고객")
+            .withPhone("010-1111-2222")
+            .build();
 
         ExtractableResponse<Response> response = given()
-                .contentType("application/json")
-                .body(validReservation)
-                .when()
-                .post("/api/reservations")
-                .then()
-                .extract();
+            .contentType("application/json")
+            .body(validReservation)
+            .when()
+            .post("/api/reservations")
+            .then()
+            .extract();
 
         // then - 예약에 성공한다
         assertThat(response.statusCode()).isEqualTo(CREATED.value());
@@ -198,19 +200,19 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         LocalDate endDate = LocalDate.now().plusDays(31);
 
         Map<String, Object> validReservation = new ReservationTestDataBuilder()
-                .withSiteNumber("B-4")
-                .withDates(startDate, endDate)
-                .withName("30일경계고객")
-                .withPhone("010-2222-3333")
-                .build();
+            .withSiteNumber("B-4")
+            .withDates(startDate, endDate)
+            .withName("30일경계고객")
+            .withPhone("010-2222-3333")
+            .build();
 
         ExtractableResponse<Response> response = given()
-                .contentType("application/json")
-                .body(validReservation)
-                .when()
-                    .post("/api/reservations")
-                .then()
-                    .extract();
+            .contentType("application/json")
+            .body(validReservation)
+            .when()
+            .post("/api/reservations")
+            .then()
+            .extract();
 
         // then - 예약에 성공한다
         assertThat(response.statusCode()).isEqualTo(CREATED.value());
@@ -222,19 +224,19 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         LocalDate sameDate = LocalDate.now().plusDays(15);
 
         Map<String, Object> sameDayReservation = new ReservationTestDataBuilder()
-                .withSiteNumber("B-5")
-                .withDates(sameDate, sameDate)
-                .withName("당일예약고객")
-                .withPhone("010-3333-4444")
-                .build();
+            .withSiteNumber("B-5")
+            .withDates(sameDate, sameDate)
+            .withName("당일예약고객")
+            .withPhone("010-3333-4444")
+            .build();
 
         ExtractableResponse<Response> response = given()
-                .contentType("application/json")
-                .body(sameDayReservation)
-                .when()
-                    .post("/api/reservations")
-                .then()
-                    .extract();
+            .contentType("application/json")
+            .body(sameDayReservation)
+            .when()
+            .post("/api/reservations")
+            .then()
+            .extract();
 
         // then - 예약에 성공한다
         assertThat(response.statusCode()).isEqualTo(CREATED.value());
@@ -246,19 +248,19 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         LocalDate today = LocalDate.now();
 
         Map<String, Object> todayReservation = new ReservationTestDataBuilder()
-                .withSiteNumber("B-6")
-                .withDates(today, today.plusDays(1))
-                .withName("오늘예약고객")
-                .withPhone("010-4444-5555")
-                .build();
+            .withSiteNumber("B-6")
+            .withDates(today, today.plusDays(1))
+            .withName("오늘예약고객")
+            .withPhone("010-4444-5555")
+            .build();
 
         ExtractableResponse<Response> response = given()
-                .contentType("application/json")
-                .body(todayReservation)
-                .when()
-                .post("/api/reservations")
-                .then()
-                .extract();
+            .contentType("application/json")
+            .body(todayReservation)
+            .when()
+            .post("/api/reservations")
+            .then()
+            .extract();
 
         // then - 예약에 성공한다
         assertThat(response.statusCode()).isEqualTo(CREATED.value());
@@ -271,19 +273,19 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         LocalDate endDate = LocalDate.now().plusDays(12);
 
         Map<String, Object> invalidSiteReservation = new ReservationTestDataBuilder()
-                .withSiteNumber("Z-99")  // 존재하지 않는 캠핑장
-                .withDates(startDate, endDate)
-                .withName("잘못된사이트고객")
-                .withPhone("010-5555-6666")
-                .build();
+            .withSiteNumber("Z-99")  // 존재하지 않는 캠핑장
+            .withDates(startDate, endDate)
+            .withName("잘못된사이트고객")
+            .withPhone("010-5555-6666")
+            .build();
 
         ExtractableResponse<Response> response = given()
-                .contentType("application/json")
-                .body(invalidSiteReservation)
-                .when()
-                .post("/api/reservations")
-                .then()
-                .extract();
+            .contentType("application/json")
+            .body(invalidSiteReservation)
+            .when()
+            .post("/api/reservations")
+            .then()
+            .extract();
 
         // then - "존재하지 않는 캠핑장입니다" 오류가 발생한다
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
@@ -305,19 +307,19 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             executorService.execute(() -> {
                 try {
                     Map<String, Object> request = new ReservationTestDataBuilder()
-                            .withSiteNumber("B-7")
-                            .withDates(startDate, endDate)
-                            .withName("최소동시고객" + customerIndex)
-                            .withPhone("010-6666-777" + customerIndex)
-                            .build();
+                        .withSiteNumber("B-7")
+                        .withDates(startDate, endDate)
+                        .withName("최소동시고객" + customerIndex)
+                        .withPhone("010-6666-777" + customerIndex)
+                        .build();
 
                     ExtractableResponse<Response> response = given()
-                            .contentType("application/json")
-                            .body(request)
-                            .when()
-                            .post("/api/reservations")
-                            .then()
-                            .extract();
+                        .contentType("application/json")
+                        .body(request)
+                        .when()
+                        .post("/api/reservations")
+                        .then()
+                        .extract();
 
                     synchronized (responses) {
                         responses.add(response);
@@ -337,14 +339,14 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
 
         // then - 한 명만 예약에 성공하고 한 명은 실패한다
         long successCount = responses.stream()
-                .mapToInt(ExtractableResponse::statusCode)
-                .filter(status -> status == CREATED.value())
-                .count();
+            .mapToInt(ExtractableResponse::statusCode)
+            .filter(status -> status == CREATED.value())
+            .count();
 
         long conflictCount = responses.stream()
-                .mapToInt(ExtractableResponse::statusCode)
-                .filter(status -> status == CONFLICT.value())
-                .count();
+            .mapToInt(ExtractableResponse::statusCode)
+            .filter(status -> status == CONFLICT.value())
+            .count();
 
         assertThat(successCount).isEqualTo(1);
         assertThat(conflictCount).isEqualTo(1);
@@ -355,19 +357,225 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
     void 날짜가_null인_요청_시_예약_실패() {
         // when - 고객이 null 날짜로 예약을 시도하면
         Map<String, Object> invalidReservation = new ReservationTestDataBuilder()
-                .withStartDate(null)
-                .build();
+            .withStartDate(null)
+            .build();
 
         ExtractableResponse<Response> response = given()
-                .contentType("application/json")
-                .body(invalidReservation)
-                .when()
-                    .post("/api/reservations")
-                .then()
-                    .extract();
+            .contentType("application/json")
+            .body(invalidReservation)
+            .when()
+            .post("/api/reservations")
+            .then()
+            .extract();
 
-        // then - 예약이 실패한다
+        // then - 예약에 실패한다
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
         assertThat(response.jsonPath().getString("message")).isEqualTo("예약 기간을 선택해주세요.");
+    }
+
+    @Test
+    void 기존_예약을_완전히_포함하는_예약_실패() {
+        // given - B-10 캠핑 구역에 12월 10일부터 13일까지 예약이 있을 때
+        LocalDate existingStart = LocalDate.now().plusDays(10);
+        LocalDate existingEnd = LocalDate.now().plusDays(13);
+
+        // 기존 예약 생성
+        Map<String, Object> existingReservation = new ReservationTestDataBuilder()
+            .withSiteNumber("B-10")
+            .withDates(existingStart, existingEnd)
+            .build();
+
+        given()
+            .contentType("application/json")
+            .body(existingReservation)
+            .when()
+                .post("/api/reservations")
+            .then()
+                .statusCode(CREATED.value());
+
+        // when - 동일한 캠핑 구역을 9일부터 14일까지 예약하려고 하면
+        LocalDate newStart = LocalDate.now().plusDays(9);
+        LocalDate newEnd = LocalDate.now().plusDays(14);
+
+        Map<String, Object> newReservation = new ReservationTestDataBuilder()
+            .withSiteNumber("B-10")
+            .withDates(newStart, newEnd)
+            .build();
+
+        ExtractableResponse<Response> response = given()
+            .contentType("application/json")
+            .body(newReservation)
+            .when()
+                .post("/api/reservations")
+            .then()
+                .extract();
+
+        // then - "해당 기간에 이미 예약이 존재합니다."라는 안내 메세지가 나타난다.
+        assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
+        assertThat(response.jsonPath().getString("message")).isEqualTo("해당 기간에 이미 예약이 존재합니다.");
+    }
+
+    @Test
+    void 기존_예약_안에_포함되는_예약_실패() {
+        // given - B-11 캠핑 구역에 12월 15일부터 20일까지 예약이 있을 때
+        LocalDate existingStart = LocalDate.now().plusDays(15);
+        LocalDate existingEnd = LocalDate.now().plusDays(20);
+
+        // 기존 예약 생성
+        Map<String, Object> existingReservation = new ReservationTestDataBuilder()
+            .withSiteNumber("B-11")
+            .withDates(existingStart, existingEnd)
+            .build();
+
+        given()
+            .contentType("application/json")
+            .body(existingReservation)
+            .when()
+                .post("/api/reservations")
+            .then()
+                .statusCode(CREATED.value());
+
+        // when - 동일한 캠핑 구역을 16일부터 18일까지 예약하려고 하면
+        LocalDate newStart = LocalDate.now().plusDays(16);
+        LocalDate newEnd = LocalDate.now().plusDays(18);
+
+        Map<String, Object> newReservation = new ReservationTestDataBuilder()
+            .withSiteNumber("B-11")
+            .withDates(newStart, newEnd)
+            .build();
+
+        ExtractableResponse<Response> response = given()
+            .contentType("application/json")
+            .body(newReservation)
+            .when()
+                .post("/api/reservations")
+            .then()
+                .extract();
+
+        // then - "해당 기간에 이미 예약이 존재합니다."라는 안내 메세지가 나타난다
+        assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
+        assertThat(response.jsonPath().getString("message")).isEqualTo("해당 기간에 이미 예약이 존재합니다.");
+    }
+
+    @Test
+    void 시작일만_겹치는_예약_실패() {
+        // given - B-12 캠핑 구역에 20일부터 23일까지 예약이 있을 때
+        LocalDate existingStart = LocalDate.now().plusDays(20);
+        LocalDate existingEnd = LocalDate.now().plusDays(23);
+
+        Map<String, Object> existingReservation = new ReservationTestDataBuilder()
+            .withSiteNumber("B-12")
+            .withDates(existingStart, existingEnd)
+            .build();
+
+        given()
+            .contentType("application/json")
+            .body(existingReservation)
+            .when()
+                .post("/api/reservations")
+            .then()
+                .statusCode(CREATED.value());
+
+        // when - 동일한 캠핑 구역을 22일부터 25일까지 예약하려고 하면
+        LocalDate newStart = LocalDate.now().plusDays(22);
+        LocalDate newEnd = LocalDate.now().plusDays(25);
+
+        Map<String, Object> newReservation = new ReservationTestDataBuilder()
+            .withSiteNumber("B-12")
+            .withDates(newStart, newEnd)
+            .build();
+
+        ExtractableResponse<Response> response = given()
+            .contentType("application/json")
+            .body(newReservation)
+            .when()
+                .post("/api/reservations")
+            .then()
+                .extract();
+
+        // then - "해당 기간에 이미 예약이 존재합니다."라는 안내 메세지가 나타난다.
+        assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
+        assertThat(response.jsonPath().getString("message")).isEqualTo("해당 기간에 이미 예약이 존재합니다.");
+    }
+
+    @Test
+    void 종료일만_겹치는_예약_실패() {
+        // given - B-13 캠핑 구역에 25일부터 28일까지 예약이 있을 때
+        LocalDate existingStart = LocalDate.now().plusDays(25);
+        LocalDate existingEnd = LocalDate.now().plusDays(28);
+
+        Map<String, Object> existingReservation = new ReservationTestDataBuilder()
+            .withSiteNumber("B-13")
+            .withDates(existingStart, existingEnd)
+            .build();
+
+        given()
+            .contentType("application/json")
+            .body(existingReservation)
+            .when()
+                .post("/api/reservations")
+            .then()
+                .statusCode(CREATED.value());
+
+        // when - 동일한 캠핑 구역을 23일부터 26일까지 예약하려고 하면
+        LocalDate newStart = LocalDate.now().plusDays(23);
+        LocalDate newEnd = LocalDate.now().plusDays(26);
+
+        Map<String, Object> newReservation = new ReservationTestDataBuilder()
+            .withSiteNumber("B-13")
+            .withDates(newStart, newEnd)
+            .build();
+
+        ExtractableResponse<Response> response = given()
+            .contentType("application/json")
+            .body(newReservation)
+            .when()
+                .post("/api/reservations")
+            .then()
+                .extract();
+
+        // then - "해당 기간에 이미 예약이 존재합니다."라는 안내 메세지가 나타난다.
+        assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
+        assertThat(response.jsonPath().getString("message")).isEqualTo("해당 기간에 이미 예약이 존재합니다.");
+    }
+
+    @Test
+    void 연속된_날짜_예약_성공() {
+        // given - B-14 캠핑 구역에 12월 1일부터 3일까지 예약이 있을 때
+        LocalDate existingStart = LocalDate.now().plusDays(1);
+        LocalDate existingEnd = LocalDate.now().plusDays(3);
+
+        Map<String, Object> existingReservation = new ReservationTestDataBuilder()
+            .withSiteNumber("B-14")
+            .withDates(existingStart, existingEnd)
+            .build();
+
+        given()
+            .contentType("application/json")
+            .body(existingReservation)
+            .when()
+                .post("/api/reservations")
+            .then()
+                .statusCode(CREATED.value());
+
+        // when - 동일한 캠핑 구역을 4일부터 6일까지 예약하려고 하면
+        LocalDate newStart = LocalDate.now().plusDays(4);
+        LocalDate newEnd = LocalDate.now().plusDays(6);
+
+        Map<String, Object> newReservation = new ReservationTestDataBuilder()
+            .withSiteNumber("B-14")
+            .withDates(newStart, newEnd)
+            .build();
+
+        ExtractableResponse<Response> response = given()
+            .contentType("application/json")
+            .body(newReservation)
+            .when()
+                .post("/api/reservations")
+            .then()
+                .extract();
+
+        // then - 예약에 성공한다
+        assertThat(response.statusCode()).isEqualTo(CREATED.value());
     }
 }

--- a/src/test/java/com/camping/legacy/acceptance/ReservationStayAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/acceptance/ReservationStayAcceptanceTest.java
@@ -5,10 +5,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.CREATED;
 
+import com.camping.legacy.acceptance.support.ReservationTestDataBuilder;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.time.LocalDate;
-import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -19,17 +19,16 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
     void 중간_날짜에_다른_예약이_있으면_예약_불가() {
         // given - A-5 캠핑 구역이 12월 22일부터 23일까지 예약되어 있을 때
         int currentYear = LocalDate.now().getYear();
-        LocalDate startDate = LocalDate.of(currentYear, 12, 22);
-        LocalDate endDate = LocalDate.of(currentYear, 12, 23);
+        LocalDate conflictDate = LocalDate.of(currentYear, 12, 22);
 
         // 기존 예약 생성
-        Map<String, Object> existingReservation = new HashMap<>();
-        existingReservation.put("siteNumber", "A-5");
-        existingReservation.put("startDate", startDate.toString());
-        existingReservation.put("endDate", endDate.toString());
-        existingReservation.put("customerName", "기존예약고객");
-        existingReservation.put("phoneNumber", "010-7777-7777");
-
+        Map<String, Object> existingReservation = new ReservationTestDataBuilder()
+                .withSiteNumber("A-5")
+                .withDates(conflictDate, conflictDate.plusDays(1))
+                .withName("기존예약고객")
+                .withPhone("010-7777-7777")
+                .build();
+        
         given()
                 .contentType("application/json")
                 .body(existingReservation)
@@ -39,15 +38,15 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
                 .statusCode(CREATED.value());
         
         // when - 고객이 12월 20일부터 24일까지 예약하려고 하면
-        startDate = LocalDate.of(currentYear, 12, 20);
-        endDate = LocalDate.of(currentYear, 12, 24);
+        LocalDate startDate = LocalDate.of(currentYear, 12, 20);
+        LocalDate endDate = LocalDate.of(currentYear, 12, 24);
         
-        Map<String, Object> newReservation = new HashMap<>();
-        newReservation.put("siteNumber", "A-5");
-        newReservation.put("startDate", startDate.toString());
-        newReservation.put("endDate", endDate.toString());
-        newReservation.put("customerName", "연박예약고객");
-        newReservation.put("phoneNumber", "010-6666-6666");
+        Map<String, Object> newReservation = new ReservationTestDataBuilder()
+                .withSiteNumber("A-5")
+                .withDates(startDate, endDate)
+                .withName("연박예약고객")
+                .withPhone("010-6666-6666")
+                .build();
         
         ExtractableResponse<Response> response = given()
                 .contentType("application/json")
@@ -69,13 +68,13 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         LocalDate startDate = LocalDate.of(currentYear, 12, 10);
         LocalDate endDate = LocalDate.of(currentYear, 12, 8);
 
-        Map<String, Object> invalidReservation = new HashMap<>();
-        invalidReservation.put("siteNumber", "A-7");
-        invalidReservation.put("startDate", startDate.toString());
-        invalidReservation.put("endDate", endDate.toString());
-        invalidReservation.put("customerName", "잘못된날짜고객");
-        invalidReservation.put("phoneNumber", "010-5555-5555");
-        
+        Map<String, Object> invalidReservation = new ReservationTestDataBuilder()
+                .withSiteNumber("A-7")
+                .withDates(startDate, endDate)
+                .withName("잘못된날짜고객")
+                .withPhone("010-5555-5555")
+                .build();
+
         ExtractableResponse<Response> response = given()
                 .contentType("application/json")
                 .body(invalidReservation)
@@ -97,12 +96,12 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         LocalDate endDate = LocalDate.of(currentYear, 12, 23);
 
         // 기존 예약 생성
-        Map<String, Object> existingReservation = new HashMap<>();
-        existingReservation.put("siteNumber", "A-2");
-        existingReservation.put("startDate", startDate.toString());
-        existingReservation.put("endDate", endDate.toString());
-        existingReservation.put("customerName", "부분충돌고객");
-        existingReservation.put("phoneNumber", "010-3333-3333");
+        Map<String, Object> existingReservation = new ReservationTestDataBuilder()
+                .withSiteNumber("B-2")
+                .withDates(startDate, endDate)
+                .withName("부분충돌고객")
+                .withPhone("010-3333-3333")
+                .build();
 
         given()
                 .contentType("application/json")
@@ -116,12 +115,12 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         startDate = LocalDate.of(currentYear, 12, 20);
         endDate = LocalDate.of(currentYear, 12, 22);
 
-        Map<String, Object> overlappingReservation = new HashMap<>();
-        overlappingReservation.put("siteNumber", "A-2");
-        overlappingReservation.put("startDate", startDate.toString());
-        overlappingReservation.put("endDate", endDate.toString());
-        overlappingReservation.put("customerName", "부분예약고객");
-        overlappingReservation.put("phoneNumber", "010-2222-2222");
+        Map<String, Object> overlappingReservation = new ReservationTestDataBuilder()
+                .withSiteNumber("B-2")
+                .withDates(startDate, endDate)
+                .withName("부분예약고객")
+                .withPhone("010-2222-2222")
+                .build();
 
         ExtractableResponse<Response> response = given()
                 .contentType("application/json")
@@ -142,12 +141,12 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         LocalDate startDate = clockProvider.now().plusDays(31);
         LocalDate endDate = clockProvider.now().plusDays(33);
 
-        Map<String, Object> futureReservation = new HashMap<>();
-        futureReservation.put("siteNumber", "A-8");
-        futureReservation.put("startDate", startDate.toString());
-        futureReservation.put("endDate", endDate.toString());
-        futureReservation.put("customerName", "미래예약고객");
-        futureReservation.put("phoneNumber", "010-4444-4444");
+        Map<String, Object> futureReservation = new ReservationTestDataBuilder()
+                .withSiteNumber("A-8")
+                .withDates(startDate, endDate)
+                .withName("미래예약고객")
+                .withPhone("010-4444-4444")
+                .build();
 
         ExtractableResponse<Response> response = given()
                 .contentType("application/json")
@@ -158,7 +157,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
                 .extract();
 
         // then - "예약은 30일 이내에만 가능합니다"라는 안내 메시지가 나타난다
-        assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
+        assertThat(response.statusCode()).isEqualTo(409);
         assertThat(response.jsonPath().getString("message")).isEqualTo("예약은 30일 이내에만 가능합니다");
     }
 }

--- a/src/test/java/com/camping/legacy/acceptance/ReservationStayAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/acceptance/ReservationStayAcceptanceTest.java
@@ -139,8 +139,8 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
     @Test
     void _30일_이내만_예약_가능() {
         // when - 고객이 오늘로부터 31일 이후의 날짜로 예약하려고 하면
-        LocalDate startDate = LocalDate.now().plusDays(31);
-        LocalDate endDate = LocalDate.now().plusDays(33);
+        LocalDate startDate = clockProvider.now().plusDays(31);
+        LocalDate endDate = clockProvider.now().plusDays(33);
 
         Map<String, Object> futureReservation = new HashMap<>();
         futureReservation.put("siteNumber", "A-8");

--- a/src/test/java/com/camping/legacy/acceptance/ReservationStayAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/acceptance/ReservationStayAcceptanceTest.java
@@ -32,17 +32,15 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         Map<String, Object> existingReservation = new ReservationTestDataBuilder()
             .withSiteNumber("A-5")
             .withDates(conflictDate, conflictDate.plusDays(1))
-            .withName("기존예약고객")
-            .withPhone("010-7777-7777")
             .build();
 
         given()
             .contentType("application/json")
             .body(existingReservation)
             .when()
-            .post("/api/reservations")
+                .post("/api/reservations")
             .then()
-            .statusCode(CREATED.value());
+                .statusCode(CREATED.value());
 
         // when - 고객이 12월 20일부터 24일까지 예약하려고 하면
         LocalDate startDate = LocalDate.of(currentYear, 12, 20);
@@ -51,19 +49,17 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         Map<String, Object> newReservation = new ReservationTestDataBuilder()
             .withSiteNumber("A-5")
             .withDates(startDate, endDate)
-            .withName("연박예약고객")
-            .withPhone("010-6666-6666")
             .build();
 
         ExtractableResponse<Response> response = given()
             .contentType("application/json")
             .body(newReservation)
             .when()
-            .post("/api/reservations")
+                .post("/api/reservations")
             .then()
-            .extract();
+                .extract();
 
-        // then - 예약에 실패한다
+        // then - "해당 기간에 이미 예약이 존재합니다." 라는 안내 메세지가 나타난다.
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
         assertThat(response.jsonPath().getString("message")).isEqualTo("해당 기간에 이미 예약이 존재합니다.");
     }
@@ -78,26 +74,24 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         Map<String, Object> invalidReservation = new ReservationTestDataBuilder()
             .withSiteNumber("A-7")
             .withDates(startDate, endDate)
-            .withName("잘못된날짜고객")
-            .withPhone("010-5555-5555")
             .build();
 
         ExtractableResponse<Response> response = given()
             .contentType("application/json")
             .body(invalidReservation)
             .when()
-            .post("/api/reservations")
+                .post("/api/reservations")
             .then()
-            .extract();
+                .extract();
 
-        // then - 예약에 실패한다
+        // then - "종료일이 시작일보다 이전일 수 없습니다." 라는 안내 메세지가 나타난다.
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
         assertThat(response.jsonPath().getString("message")).isEqualTo("종료일이 시작일보다 이전일 수 없습니다.");
     }
 
     @Test
     void 일부_날짜만_가능해도_전체_예약_불가() {
-        // given - A-2 캠핑 구역이 12월 20일, 21일은 비어있지만 22일은 예약되어 있을 때
+        // given - A-2 캠핑 구역이 12월 22일이 예약되어 있을 때
         int currentYear = LocalDate.now().getYear();
         LocalDate startDate = LocalDate.of(currentYear, 12, 22);
         LocalDate endDate = LocalDate.of(currentYear, 12, 23);
@@ -106,17 +100,15 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         Map<String, Object> existingReservation = new ReservationTestDataBuilder()
             .withSiteNumber("B-2")
             .withDates(startDate, endDate)
-            .withName("부분충돌고객")
-            .withPhone("010-3333-3333")
             .build();
 
         given()
             .contentType("application/json")
             .body(existingReservation)
             .when()
-            .post("/api/reservations")
+                .post("/api/reservations")
             .then()
-            .statusCode(CREATED.value());
+                .statusCode(CREATED.value());
 
         // when - 고객이 12월 20일부터 22일까지 예약하려고 하면
         startDate = LocalDate.of(currentYear, 12, 20);
@@ -125,19 +117,17 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         Map<String, Object> overlappingReservation = new ReservationTestDataBuilder()
             .withSiteNumber("B-2")
             .withDates(startDate, endDate)
-            .withName("부분예약고객")
-            .withPhone("010-2222-2222")
             .build();
 
         ExtractableResponse<Response> response = given()
             .contentType("application/json")
             .body(overlappingReservation)
             .when()
-            .post("/api/reservations")
+                .post("/api/reservations")
             .then()
-            .extract();
+                .extract();
 
-        // then - 예약할 수 없다
+        // then - "해당 기간에 이미 예약이 존재합니다." 라는 안내 메세지가 나타난다.
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
         assertThat(response.jsonPath().getString("message")).isEqualTo("해당 기간에 이미 예약이 존재합니다.");
     }
@@ -151,17 +141,15 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         Map<String, Object> futureReservation = new ReservationTestDataBuilder()
             .withSiteNumber("A-8")
             .withDates(startDate, endDate)
-            .withName("미래예약고객")
-            .withPhone("010-4444-4444")
             .build();
 
         ExtractableResponse<Response> response = given()
             .contentType("application/json")
             .body(futureReservation)
             .when()
-            .post("/api/reservations")
+                .post("/api/reservations")
             .then()
-            .extract();
+                .extract();
 
         // then - "예약은 30일 이내에만 가능합니다"라는 안내 메시지가 나타난다
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
@@ -177,17 +165,15 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         Map<String, Object> validReservation = new ReservationTestDataBuilder()
             .withSiteNumber("B-3")
             .withDates(startDate, endDate)
-            .withName("29일경계고객")
-            .withPhone("010-1111-2222")
             .build();
 
         ExtractableResponse<Response> response = given()
             .contentType("application/json")
             .body(validReservation)
             .when()
-            .post("/api/reservations")
+                .post("/api/reservations")
             .then()
-            .extract();
+                .extract();
 
         // then - 예약에 성공한다
         assertThat(response.statusCode()).isEqualTo(CREATED.value());
@@ -202,17 +188,15 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         Map<String, Object> validReservation = new ReservationTestDataBuilder()
             .withSiteNumber("B-4")
             .withDates(startDate, endDate)
-            .withName("30일경계고객")
-            .withPhone("010-2222-3333")
             .build();
 
         ExtractableResponse<Response> response = given()
             .contentType("application/json")
             .body(validReservation)
             .when()
-            .post("/api/reservations")
+                .post("/api/reservations")
             .then()
-            .extract();
+                .extract();
 
         // then - 예약에 성공한다
         assertThat(response.statusCode()).isEqualTo(CREATED.value());
@@ -226,17 +210,15 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         Map<String, Object> sameDayReservation = new ReservationTestDataBuilder()
             .withSiteNumber("B-5")
             .withDates(sameDate, sameDate)
-            .withName("당일예약고객")
-            .withPhone("010-3333-4444")
             .build();
 
         ExtractableResponse<Response> response = given()
             .contentType("application/json")
             .body(sameDayReservation)
             .when()
-            .post("/api/reservations")
+                .post("/api/reservations")
             .then()
-            .extract();
+                .extract();
 
         // then - 예약에 성공한다
         assertThat(response.statusCode()).isEqualTo(CREATED.value());
@@ -250,17 +232,15 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         Map<String, Object> todayReservation = new ReservationTestDataBuilder()
             .withSiteNumber("B-6")
             .withDates(today, today.plusDays(1))
-            .withName("오늘예약고객")
-            .withPhone("010-4444-5555")
             .build();
 
         ExtractableResponse<Response> response = given()
             .contentType("application/json")
             .body(todayReservation)
             .when()
-            .post("/api/reservations")
+                .post("/api/reservations")
             .then()
-            .extract();
+                .extract();
 
         // then - 예약에 성공한다
         assertThat(response.statusCode()).isEqualTo(CREATED.value());
@@ -275,19 +255,17 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         Map<String, Object> invalidSiteReservation = new ReservationTestDataBuilder()
             .withSiteNumber("Z-99")  // 존재하지 않는 캠핑장
             .withDates(startDate, endDate)
-            .withName("잘못된사이트고객")
-            .withPhone("010-5555-6666")
             .build();
 
         ExtractableResponse<Response> response = given()
             .contentType("application/json")
             .body(invalidSiteReservation)
             .when()
-            .post("/api/reservations")
+                .post("/api/reservations")
             .then()
-            .extract();
+                .extract();
 
-        // then - "존재하지 않는 캠핑장입니다" 오류가 발생한다
+        // then - "존재하지 않는 캠핑장입니다" 안내 메세지가 나타난다.
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
         assertThat(response.jsonPath().getString("message")).contains("존재하지 않는 캠핑장");
     }
@@ -364,11 +342,11 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
             .contentType("application/json")
             .body(invalidReservation)
             .when()
-            .post("/api/reservations")
+                .post("/api/reservations")
             .then()
-            .extract();
+                .extract();
 
-        // then - 예약에 실패한다
+        // then - "예약 기간을 선택해주세요." 라는 안내 메세지가 나타난다.
         assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
         assertThat(response.jsonPath().getString("message")).isEqualTo("예약 기간을 선택해주세요.");
     }
@@ -376,8 +354,8 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
     @Test
     void 기존_예약을_완전히_포함하는_예약_실패() {
         // given - B-10 캠핑 구역에 12월 10일부터 13일까지 예약이 있을 때
-        LocalDate existingStart = LocalDate.now().plusDays(10);
-        LocalDate existingEnd = LocalDate.now().plusDays(13);
+        LocalDate existingStart = LocalDate.of(2025, 12, 10);
+        LocalDate existingEnd = LocalDate.of(2025, 12, 13);
 
         // 기존 예약 생성
         Map<String, Object> existingReservation = new ReservationTestDataBuilder()
@@ -394,8 +372,8 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
                 .statusCode(CREATED.value());
 
         // when - 동일한 캠핑 구역을 9일부터 14일까지 예약하려고 하면
-        LocalDate newStart = LocalDate.now().plusDays(9);
-        LocalDate newEnd = LocalDate.now().plusDays(14);
+        LocalDate newStart = LocalDate.of(2025, 12, 9);
+        LocalDate newEnd = LocalDate.of(2025, 12, 14);
 
         Map<String, Object> newReservation = new ReservationTestDataBuilder()
             .withSiteNumber("B-10")
@@ -418,8 +396,8 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
     @Test
     void 기존_예약_안에_포함되는_예약_실패() {
         // given - B-11 캠핑 구역에 12월 15일부터 20일까지 예약이 있을 때
-        LocalDate existingStart = LocalDate.now().plusDays(15);
-        LocalDate existingEnd = LocalDate.now().plusDays(20);
+        LocalDate existingStart = LocalDate.of(2025, 12, 15);
+        LocalDate existingEnd = LocalDate.of(2025, 12, 20);
 
         // 기존 예약 생성
         Map<String, Object> existingReservation = new ReservationTestDataBuilder()
@@ -436,8 +414,8 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
                 .statusCode(CREATED.value());
 
         // when - 동일한 캠핑 구역을 16일부터 18일까지 예약하려고 하면
-        LocalDate newStart = LocalDate.now().plusDays(16);
-        LocalDate newEnd = LocalDate.now().plusDays(18);
+        LocalDate newStart = LocalDate.of(2025, 12, 16);
+        LocalDate newEnd = LocalDate.of(2025, 12, 18);
 
         Map<String, Object> newReservation = new ReservationTestDataBuilder()
             .withSiteNumber("B-11")
@@ -460,8 +438,8 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
     @Test
     void 시작일만_겹치는_예약_실패() {
         // given - B-12 캠핑 구역에 20일부터 23일까지 예약이 있을 때
-        LocalDate existingStart = LocalDate.now().plusDays(20);
-        LocalDate existingEnd = LocalDate.now().plusDays(23);
+        LocalDate existingStart = LocalDate.of(2025, 12, 20);
+        LocalDate existingEnd = LocalDate.of(2025, 12, 23);
 
         Map<String, Object> existingReservation = new ReservationTestDataBuilder()
             .withSiteNumber("B-12")
@@ -477,8 +455,8 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
                 .statusCode(CREATED.value());
 
         // when - 동일한 캠핑 구역을 22일부터 25일까지 예약하려고 하면
-        LocalDate newStart = LocalDate.now().plusDays(22);
-        LocalDate newEnd = LocalDate.now().plusDays(25);
+        LocalDate newStart = LocalDate.of(2025, 12, 22);
+        LocalDate newEnd = LocalDate.of(2025, 12, 25);
 
         Map<String, Object> newReservation = new ReservationTestDataBuilder()
             .withSiteNumber("B-12")
@@ -501,8 +479,8 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
     @Test
     void 종료일만_겹치는_예약_실패() {
         // given - B-13 캠핑 구역에 25일부터 28일까지 예약이 있을 때
-        LocalDate existingStart = LocalDate.now().plusDays(25);
-        LocalDate existingEnd = LocalDate.now().plusDays(28);
+        LocalDate existingStart = LocalDate.of(2025, 12, 25);
+        LocalDate existingEnd = LocalDate.of(2025, 12, 28);
 
         Map<String, Object> existingReservation = new ReservationTestDataBuilder()
             .withSiteNumber("B-13")
@@ -518,8 +496,8 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
                 .statusCode(CREATED.value());
 
         // when - 동일한 캠핑 구역을 23일부터 26일까지 예약하려고 하면
-        LocalDate newStart = LocalDate.now().plusDays(23);
-        LocalDate newEnd = LocalDate.now().plusDays(26);
+        LocalDate newStart = LocalDate.of(2025, 12, 23);
+        LocalDate newEnd = LocalDate.of(2025, 12, 26);
 
         Map<String, Object> newReservation = new ReservationTestDataBuilder()
             .withSiteNumber("B-13")
@@ -542,8 +520,8 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
     @Test
     void 연속된_날짜_예약_성공() {
         // given - B-14 캠핑 구역에 12월 1일부터 3일까지 예약이 있을 때
-        LocalDate existingStart = LocalDate.now().plusDays(1);
-        LocalDate existingEnd = LocalDate.now().plusDays(3);
+        LocalDate existingStart = LocalDate.of(2025, 12, 1);
+        LocalDate existingEnd = LocalDate.of(2025, 12, 3);
 
         Map<String, Object> existingReservation = new ReservationTestDataBuilder()
             .withSiteNumber("B-14")
@@ -559,8 +537,8 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
                 .statusCode(CREATED.value());
 
         // when - 동일한 캠핑 구역을 4일부터 6일까지 예약하려고 하면
-        LocalDate newStart = LocalDate.now().plusDays(4);
-        LocalDate newEnd = LocalDate.now().plusDays(6);
+        LocalDate newStart = LocalDate.of(2025, 12, 4);
+        LocalDate newEnd = LocalDate.of(2025, 12, 6);
 
         Map<String, Object> newReservation = new ReservationTestDataBuilder()
             .withSiteNumber("B-14")

--- a/src/test/java/com/camping/legacy/acceptance/ReservationStayAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/acceptance/ReservationStayAcceptanceTest.java
@@ -159,12 +159,9 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
     @Test
     void _29일_후_예약은_성공() {
         // when - B-3 캠핑 구역을 고객이 오늘로부터 29일 후의 날짜로 예약하려고 하면
-        LocalDate startDate = LocalDate.now().plusDays(29);
-        LocalDate endDate = LocalDate.now().plusDays(30);
-
         Map<String, Object> validReservation = new ReservationTestDataBuilder()
             .withSiteNumber("B-3")
-            .withDates(startDate, endDate)
+            .withDateRange(29, 30)
             .build();
 
         ExtractableResponse<Response> response = given()
@@ -182,12 +179,9 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
     @Test
     void _30일_후_예약은_성공() {
         // when - B-4 캠핑 구역을 고객이 오늘로부터 30일 후에 예약하려고 하면
-        LocalDate startDate = LocalDate.now().plusDays(30);
-        LocalDate endDate = LocalDate.now().plusDays(31);
-
         Map<String, Object> validReservation = new ReservationTestDataBuilder()
             .withSiteNumber("B-4")
-            .withDates(startDate, endDate)
+            .withDateRange(30, 31)
             .build();
 
         ExtractableResponse<Response> response = given()
@@ -209,7 +203,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
 
         Map<String, Object> sameDayReservation = new ReservationTestDataBuilder()
             .withSiteNumber("B-5")
-            .withDates(sameDate, sameDate)
+            .withSameDayReservation(sameDate)
             .build();
 
         ExtractableResponse<Response> response = given()
@@ -227,11 +221,9 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
     @Test
     void 오늘_날짜_예약_시도_성공() {
         // given - B-6 캠핑 구역을 고객이 오늘 날짜로 예약을 시도하면
-        LocalDate today = LocalDate.now();
-
         Map<String, Object> todayReservation = new ReservationTestDataBuilder()
             .withSiteNumber("B-6")
-            .withDates(today, today.plusDays(1))
+            .withTodayReservation()
             .build();
 
         ExtractableResponse<Response> response = given()
@@ -249,12 +241,9 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
     @Test
     void 존재하지_않는_캠핑장_예약_시도_실패() {
         // when - 고객이 존재하지 않는 캠핑장으로 예약하려고 하면
-        LocalDate startDate = LocalDate.now().plusDays(10);
-        LocalDate endDate = LocalDate.now().plusDays(12);
-
         Map<String, Object> invalidSiteReservation = new ReservationTestDataBuilder()
             .withSiteNumber("Z-99")  // 존재하지 않는 캠핑장
-            .withDates(startDate, endDate)
+            .withDateRange(10, 12)
             .build();
 
         ExtractableResponse<Response> response = given()
@@ -273,8 +262,6 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
     @Test
     void 최소_동시성_2명_예약_시도() {
         // when - 2명의 고객이 동시에 같은 기간으로 B-7 캠핑 구역을 예약하려고 하면
-        LocalDate startDate = LocalDate.now().plusDays(10);
-        LocalDate endDate = LocalDate.now().plusDays(12);
 
         ExecutorService executorService = Executors.newFixedThreadPool(2);
         CountDownLatch latch = new CountDownLatch(2);
@@ -286,7 +273,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
                 try {
                     Map<String, Object> request = new ReservationTestDataBuilder()
                         .withSiteNumber("B-7")
-                        .withDates(startDate, endDate)
+                        .withDateRange(10, 12)
                         .withName("최소동시고객" + customerIndex)
                         .withPhone("010-6666-777" + customerIndex)
                         .build();
@@ -335,7 +322,7 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
     void 날짜가_null인_요청_시_예약_실패() {
         // when - 고객이 null 날짜로 예약을 시도하면
         Map<String, Object> invalidReservation = new ReservationTestDataBuilder()
-            .withStartDate(null)
+            .withoutDates()
             .build();
 
         ExtractableResponse<Response> response = given()

--- a/src/test/java/com/camping/legacy/acceptance/ReservationStayAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/acceptance/ReservationStayAcceptanceTest.java
@@ -350,4 +350,24 @@ class ReservationStayAcceptanceTest extends BaseAcceptanceTest {
         assertThat(conflictCount).isEqualTo(1);
         assertThat(responses).hasSize(2);
     }
+
+    @Test
+    void 날짜가_null인_요청_시_예약_실패() {
+        // when - 고객이 null 날짜로 예약을 시도하면
+        Map<String, Object> invalidReservation = new ReservationTestDataBuilder()
+                .withStartDate(null)
+                .build();
+
+        ExtractableResponse<Response> response = given()
+                .contentType("application/json")
+                .body(invalidReservation)
+                .when()
+                    .post("/api/reservations")
+                .then()
+                    .extract();
+
+        // then - 예약이 실패한다
+        assertThat(response.statusCode()).isEqualTo(CONFLICT.value());
+        assertThat(response.jsonPath().getString("message")).isEqualTo("예약 기간을 선택해주세요.");
+    }
 }

--- a/src/test/java/com/camping/legacy/acceptance/SiteAvailabilityAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/acceptance/SiteAvailabilityAcceptanceTest.java
@@ -2,7 +2,9 @@ package com.camping.legacy.acceptance;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
 
 import com.camping.legacy.acceptance.support.ReservationTestDataBuilder;
 import io.restassured.response.ExtractableResponse;
@@ -251,5 +253,33 @@ class SiteAvailabilityAcceptanceTest extends BaseAcceptanceTest {
         // then - "예약 가능"으로 표시된다
         assertThat(response.statusCode()).isEqualTo(OK.value());
         assertThat(response.jsonPath().getBoolean("available")).isTrue();
+    }
+
+    @Test
+    void 빈_캠핑장_번호로_가용성_조회_실패() {
+        // when - 고객이 빈 캠핑장 번호로 가용성을 조회하면
+        LocalDate queryDate = LocalDate.now().plusDays(10);
+
+        ExtractableResponse<Response> response = given()
+            .when()
+                .get("/api/sites/ /availability?date=" + queryDate)
+            .then()
+                .extract();
+
+        // then - "사이트를 찾을 수 없습니다"라는 안내 메시지가 나타난다
+        assertThat(response.jsonPath().getString("message")).contains("사이트를 찾을 수 없습니다");
+    }
+
+    @Test
+    void 날짜_파라미터_없이_가용성_조회_실패() {
+        // when - 고객이 날짜 없이 가용성을 조회하면
+        ExtractableResponse<Response> response = given()
+            .when()
+                .get("/api/sites/A-12/availability")
+            .then()
+                .extract();
+
+        // then - "필수 파라미터가 누락되었습니다"라는 안내 메시지가 나타난다
+        assertThat(response.jsonPath().getString("message")).contains("date");
     }
 }

--- a/src/test/java/com/camping/legacy/acceptance/SiteAvailabilityAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/acceptance/SiteAvailabilityAcceptanceTest.java
@@ -5,10 +5,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
+import com.camping.legacy.acceptance.support.ReservationTestDataBuilder;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.time.LocalDate;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -26,12 +26,12 @@ class SiteAvailabilityAcceptanceTest extends BaseAcceptanceTest {
         LocalDate reservedDate = LocalDate.of(2025, 12, 25);
 
         // 기존 예약 생성
-        Map<String, Object> existingReservation = new HashMap<>();
-        existingReservation.put("siteNumber", "A-3");
-        existingReservation.put("startDate", reservedDate.toString());
-        existingReservation.put("endDate", reservedDate.plusDays(1).toString());
-        existingReservation.put("customerName", "예약된고객");
-        existingReservation.put("phoneNumber", "010-1111-1111");
+        Map<String, Object> existingReservation = new ReservationTestDataBuilder()
+                .withSiteNumber("A-3")
+                .withDates(reservedDate, reservedDate.plusDays(1))
+                .withName("예약된고객")
+                .withPhone("010-1111-1111")
+                .build();
         
         given()
                 .contentType("application/json")
@@ -76,13 +76,13 @@ class SiteAvailabilityAcceptanceTest extends BaseAcceptanceTest {
         // when - 고객A가 A-6 캠핑 구역을 12월 25일에 예약한 직후
         LocalDate targetDate = LocalDate.of(2025, 12, 25);
 
-        Map<String, Object> reservation = new HashMap<>();
-        reservation.put("siteNumber", "A-6");
-        reservation.put("startDate", targetDate.toString());
-        reservation.put("endDate", targetDate.plusDays(1).toString());
-        reservation.put("customerName", "고객A");
-        reservation.put("phoneNumber", "010-2222-2222");
-        
+        Map<String, Object> reservation = new ReservationTestDataBuilder()
+                .withSiteNumber("A-6")
+                .withDates(targetDate, targetDate.plusDays(1))
+                .withName("고객A")
+                .withPhone("010-2222-2222")
+                .build();
+
         given()
                 .contentType("application/json")
                 .body(reservation)
@@ -110,12 +110,12 @@ class SiteAvailabilityAcceptanceTest extends BaseAcceptanceTest {
         LocalDate checkDate = LocalDate.of(2025, 12, 25);
 
         // 기존 예약 생성
-        Map<String, Object> existingReservation = new HashMap<>();
-        existingReservation.put("siteNumber", "A-8");
-        existingReservation.put("startDate", checkDate.toString());
-        existingReservation.put("endDate", checkDate.plusDays(1).toString());
-        existingReservation.put("customerName", "기존고객");
-        existingReservation.put("phoneNumber", "010-3333-3333");
+        Map<String, Object> existingReservation = new ReservationTestDataBuilder()
+                .withSiteNumber("A-8")
+                .withDates(checkDate, checkDate.plusDays(1))
+                .withName("기존고객")
+                .withPhone("010-3333-3333")
+                .build();
         
         given()
                 .contentType("application/json")

--- a/src/test/java/com/camping/legacy/acceptance/SiteAvailabilityAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/acceptance/SiteAvailabilityAcceptanceTest.java
@@ -2,13 +2,13 @@ package com.camping.legacy.acceptance;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
 import com.camping.legacy.acceptance.support.ReservationTestDataBuilder;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
@@ -16,6 +16,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.ArrayList;
+
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -28,31 +29,28 @@ class SiteAvailabilityAcceptanceTest extends BaseAcceptanceTest {
 
         // 기존 예약 생성
         Map<String, Object> existingReservation = new ReservationTestDataBuilder()
-                .withSiteNumber("A-3")
-                .withDates(reservedDate, reservedDate.plusDays(1))
-                .withName("예약된고객")
-                .withPhone("010-1111-1111")
-                .build();
-        
+            .withSiteNumber("A-3")
+            .withDates(reservedDate, reservedDate.plusDays(1))
+            .build();
+
         given()
-                .contentType("application/json")
-                .body(existingReservation)
-        .when()
+            .contentType("application/json")
+            .body(existingReservation)
+            .when()
                 .post("/api/reservations")
-        .then()
+            .then()
                 .statusCode(CREATED.value());
-        
+
         // when - 고객이 12월 25일에 A-3 캠핑 구역의 예약 가능 여부를 확인하면
         ExtractableResponse<Response> response = given()
-        .when()
+            .when()
                 .get("/api/sites/A-3/availability?date=" + reservedDate)
-        .then()
+            .then()
                 .extract();
-        
+
         // then - "예약 불가능"으로 표시된다
         assertThat(response.statusCode()).isEqualTo(OK.value());
         assertThat(response.jsonPath().getBoolean("available")).isFalse();
-        assertThat(response.jsonPath().getString("siteNumber")).isEqualTo("A-3");
     }
 
     @Test
@@ -61,15 +59,13 @@ class SiteAvailabilityAcceptanceTest extends BaseAcceptanceTest {
         LocalDate availableDate = LocalDate.of(2025, 12, 25);
 
         ExtractableResponse<Response> response = given()
-                .when()
-                    .get("/api/sites/A-4/availability?date=" + availableDate)
-                .then()
-                    .extract();
-        
+            .when()
+               .get("/api/sites/A-4/availability?date=" + availableDate)
+            .then()
+                .extract();
+
         // then - "예약 가능"으로 표시된다
-        assertThat(response.statusCode()).isEqualTo(OK.value());
         assertThat(response.jsonPath().getBoolean("available")).isTrue();
-        assertThat(response.jsonPath().getString("siteNumber")).isEqualTo("A-4");
     }
 
     @Test
@@ -78,31 +74,28 @@ class SiteAvailabilityAcceptanceTest extends BaseAcceptanceTest {
         LocalDate targetDate = LocalDate.of(2025, 12, 25);
 
         Map<String, Object> reservation = new ReservationTestDataBuilder()
-                .withSiteNumber("A-6")
-                .withDates(targetDate, targetDate.plusDays(1))
-                .withName("고객A")
-                .withPhone("010-2222-2222")
-                .build();
+            .withSiteNumber("A-6")
+            .withDates(targetDate, targetDate.plusDays(1))
+            .withName("고객A")
+            .build();
 
         given()
-                .contentType("application/json")
-                .body(reservation)
-        .when()
+            .contentType("application/json")
+            .body(reservation)
+            .when()
                 .post("/api/reservations")
-        .then()
+            .then()
                 .statusCode(CREATED.value());
-        
+
         // and - 고객B가 같은 날짜의 예약 가능 여부를 확인하면
         ExtractableResponse<Response> response = given()
-        .when()
-                .get("/api/sites/A-6/availability?date=" + targetDate)
-        .then()
-                .extract();
-        
+            .when()
+            .get("/api/sites/A-6/availability?date=" + targetDate)
+            .then()
+            .extract();
+
         // then - "예약 불가능"으로 표시된다
-        assertThat(response.statusCode()).isEqualTo(OK.value());
         assertThat(response.jsonPath().getBoolean("available")).isFalse();
-        assertThat(response.jsonPath().getString("siteNumber")).isEqualTo("A-6");
     }
 
     @Test
@@ -112,34 +105,32 @@ class SiteAvailabilityAcceptanceTest extends BaseAcceptanceTest {
 
         // 기존 예약 생성
         Map<String, Object> existingReservation = new ReservationTestDataBuilder()
-                .withSiteNumber("A-8")
-                .withDates(checkDate, checkDate.plusDays(1))
-                .withName("기존고객")
-                .withPhone("010-3333-3333")
-                .build();
-        
+            .withSiteNumber("A-8")
+            .withDates(checkDate, checkDate.plusDays(1))
+            .build();
+
         given()
-                .contentType("application/json")
-                .body(existingReservation)
-        .when()
-                .post("/api/reservations")
-        .then()
+            .contentType("application/json")
+            .body(existingReservation)
+            .when()
+               .post("/api/reservations")
+            .then()
                 .statusCode(CREATED.value());
-        
+
         // when - 10명의 고객이 동시에 A-8 캠핑 구역의 예약 가능 여부를 확인하면
         ExecutorService executorService = Executors.newFixedThreadPool(10);
         CountDownLatch latch = new CountDownLatch(10);
         List<ExtractableResponse<Response>> responses = new ArrayList<>();
-        
+
         for (int i = 0; i < 10; i++) {
             executorService.execute(() -> {
                 try {
                     ExtractableResponse<Response> response = given()
-                    .when()
-                            .get("/api/sites/A-8/availability?date=" + checkDate)
-                    .then()
-                            .extract();
-                    
+                        .when()
+                        .get("/api/sites/A-8/availability?date=" + checkDate)
+                        .then()
+                        .extract();
+
                     synchronized (responses) {
                         responses.add(response);
                     }
@@ -148,21 +139,19 @@ class SiteAvailabilityAcceptanceTest extends BaseAcceptanceTest {
                 }
             });
         }
-        
+
         try {
             latch.await();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
         executorService.shutdown();
-        
+
         // then - 모든 고객에게 동일하게 "예약 불가능"으로 표시된다
         assertThat(responses).hasSize(10);
-        
+
         for (ExtractableResponse<Response> response : responses) {
-            assertThat(response.statusCode()).isEqualTo(OK.value());
             assertThat(response.jsonPath().getBoolean("available")).isFalse();
-            assertThat(response.jsonPath().getString("siteNumber")).isEqualTo("A-8");
         }
     }
 
@@ -172,10 +161,10 @@ class SiteAvailabilityAcceptanceTest extends BaseAcceptanceTest {
         LocalDate queryDate = LocalDate.now().plusDays(10);
 
         ExtractableResponse<Response> response = given()
-                .when()
-                    .get("/api/sites/Z-99/availability?date=" + queryDate)
-                .then()
-                    .extract();
+            .when()
+                .get("/api/sites/Z-99/availability?date=" + queryDate)
+            .then()
+                .extract();
 
         // then - "사이트를 찾을 수 없습니다"라는 안내 메시지가 나타난다
         assertThat(response.jsonPath().getString("message").contains("사이트를 찾을 수 없습니다"));
@@ -187,9 +176,9 @@ class SiteAvailabilityAcceptanceTest extends BaseAcceptanceTest {
         LocalDate availableDate = LocalDate.now().plusDays(20);
 
         ExtractableResponse<Response> response = given()
-                .when()
+            .when()
                 .get("/api/sites/A-9/availability?date=" + availableDate)
-                .then()
+            .then()
                 .extract();
 
         // then - "예약 가능"으로 표시된다
@@ -209,9 +198,9 @@ class SiteAvailabilityAcceptanceTest extends BaseAcceptanceTest {
             executorService.execute(() -> {
                 try {
                     ExtractableResponse<Response> response = given()
-                            .when()
+                        .when()
                             .get("/api/sites/A-10/availability?date=" + checkDate)
-                            .then()
+                        .then()
                             .extract();
 
                     synchronized (responses) {
@@ -245,9 +234,9 @@ class SiteAvailabilityAcceptanceTest extends BaseAcceptanceTest {
         LocalDate today = LocalDate.now();
 
         ExtractableResponse<Response> response = given()
-                .when()
+            .when()
                 .get("/api/sites/A-11/availability?date=" + today)
-                .then()
+            .then()
                 .extract();
 
         // then - "예약 가능"으로 표시된다

--- a/src/test/java/com/camping/legacy/acceptance/support/ConcurrentTestHelper.java
+++ b/src/test/java/com/camping/legacy/acceptance/support/ConcurrentTestHelper.java
@@ -1,0 +1,87 @@
+package com.camping.legacy.acceptance.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.CONFLICT;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class ConcurrentTestHelper {
+
+    public static <T> List<T> runConcurrently(int threadCount, Supplier<T> task) {
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        List<T> results = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                try {
+                    T result = task.get();
+                    synchronized (results) {
+                        results.add(result);
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        executorService.shutdown();
+
+        return results;
+    }
+
+    public static void assertConcurrentResults(List<ExtractableResponse<Response>> responses, 
+                                             int expectedSuccessCount, int expectedConflictCount) {
+        long successCount = responses.stream()
+                .mapToInt(ExtractableResponse::statusCode)
+                .filter(status -> status == CREATED.value())
+                .count();
+
+        long conflictCount = responses.stream()
+                .mapToInt(ExtractableResponse::statusCode)
+                .filter(status -> status == CONFLICT.value())
+                .count();
+
+        assertThat(successCount).isEqualTo(expectedSuccessCount);
+        assertThat(conflictCount).isEqualTo(expectedConflictCount);
+        assertThat(responses).hasSize(expectedSuccessCount + expectedConflictCount);
+    }
+
+    public static List<ExtractableResponse<Response>> executeConcurrentReservations(
+            int threadCount, Supplier<Map<String, Object>> reservationDataSupplier) {
+        return runConcurrently(threadCount, () -> 
+            ReservationApiHelper.createReservation(reservationDataSupplier.get())
+        );
+    }
+
+    public static List<ExtractableResponse<Response>> executeConcurrentReservationsWithIndex(
+            int threadCount, Function<Integer, Map<String, Object>> reservationDataFunction) {
+        return runConcurrently(threadCount, () -> {
+            int customerIndex = (int) (Thread.currentThread().getId() % threadCount);
+            return ReservationApiHelper.createReservation(reservationDataFunction.apply(customerIndex));
+        });
+    }
+
+    public static List<ExtractableResponse<Response>> executeConcurrentSiteAvailabilityChecks(
+            int threadCount, String siteNumber, LocalDate date) {
+        return runConcurrently(threadCount, () -> 
+            ReservationApiHelper.checkSiteAvailability(siteNumber, date)
+        );
+    }
+}

--- a/src/test/java/com/camping/legacy/acceptance/support/ReservationApiHelper.java
+++ b/src/test/java/com/camping/legacy/acceptance/support/ReservationApiHelper.java
@@ -1,0 +1,50 @@
+package com.camping.legacy.acceptance.support;
+
+import static io.restassured.RestAssured.given;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.time.LocalDate;
+import java.util.Map;
+
+public class ReservationApiHelper {
+
+    public static ExtractableResponse<Response> createReservation(Map<String, Object> reservationData) {
+        return given()
+                .contentType("application/json")
+                .body(reservationData)
+                .when()
+                    .post("/api/reservations")
+                .then()
+                    .extract();
+    }
+
+    public static ExtractableResponse<Response> checkSiteAvailability(String siteNumber, LocalDate date) {
+        return given()
+                .when()
+                    .get("/api/sites/" + siteNumber + "/availability?date=" + date)
+                .then()
+                    .extract();
+    }
+
+    public static ExtractableResponse<Response> createReservationAndExpectSuccess(Map<String, Object> reservationData) {
+        return createReservation(reservationData);
+    }
+
+    public static ExtractableResponse<Response> createExistingReservation(String siteNumber, LocalDate startDate, LocalDate endDate) {
+        Map<String, Object> existingReservation = new ReservationTestDataBuilder()
+                .withSiteNumber(siteNumber)
+                .withDates(startDate, endDate)
+                .build();
+        
+        return createReservation(existingReservation);
+    }
+
+    public static ExtractableResponse<Response> checkSiteAvailabilityWithoutDateParam(String siteNumber) {
+        return given()
+                .when()
+                    .get("/api/sites/" + siteNumber + "/availability")
+                .then()
+                    .extract();
+    }
+}

--- a/src/test/java/com/camping/legacy/acceptance/support/ReservationTestDataBuilder.java
+++ b/src/test/java/com/camping/legacy/acceptance/support/ReservationTestDataBuilder.java
@@ -32,11 +32,21 @@ public class ReservationTestDataBuilder {
         return this;
     }
     
+    public ReservationTestDataBuilder withStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+    
+    public ReservationTestDataBuilder withEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+    
     public Map<String, Object> build() {
         Map<String, Object> request = new HashMap<>();
         request.put("siteNumber", siteNumber);
-        request.put("startDate", startDate.toString());
-        request.put("endDate", endDate.toString());
+        request.put("startDate", startDate != null ? startDate.toString() : null);
+        request.put("endDate", endDate != null ? endDate.toString() : null);
         request.put("customerName", name);
         request.put("phoneNumber", phone);
         return request;

--- a/src/test/java/com/camping/legacy/acceptance/support/ReservationTestDataBuilder.java
+++ b/src/test/java/com/camping/legacy/acceptance/support/ReservationTestDataBuilder.java
@@ -32,16 +32,35 @@ public class ReservationTestDataBuilder {
         return this;
     }
     
-    public ReservationTestDataBuilder withStartDate(LocalDate startDate) {
-        this.startDate = startDate;
+    public ReservationTestDataBuilder withDateRange(int startDaysFromNow, int endDaysFromNow) {
+        this.startDate = LocalDate.now().plusDays(startDaysFromNow);
+        this.endDate = LocalDate.now().plusDays(endDaysFromNow);
         return this;
     }
     
-    public ReservationTestDataBuilder withEndDate(LocalDate endDate) {
-        this.endDate = endDate;
+    public ReservationTestDataBuilder withSameDayReservation(LocalDate date) {
+        this.startDate = date;
+        this.endDate = date;
         return this;
     }
     
+    public ReservationTestDataBuilder withValidFutureReservation() {
+        return withDateRange(7, 9);
+    }
+    
+    public ReservationTestDataBuilder withTodayReservation() {
+        LocalDate today = LocalDate.now();
+        this.startDate = today;
+        this.endDate = today.plusDays(1);
+        return this;
+    }
+    
+    public ReservationTestDataBuilder withoutDates() {
+        this.startDate = null;
+        this.endDate = null;
+        return this;
+    }
+
     public Map<String, Object> build() {
         Map<String, Object> request = new HashMap<>();
         request.put("siteNumber", siteNumber);

--- a/src/test/java/com/camping/legacy/acceptance/support/ReservationTestDataBuilder.java
+++ b/src/test/java/com/camping/legacy/acceptance/support/ReservationTestDataBuilder.java
@@ -1,0 +1,44 @@
+package com.camping.legacy.acceptance.support;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ReservationTestDataBuilder {
+    private String name = "기본이름";
+    private String phone = "010-0000-0000";
+    private String siteNumber = "A-1";
+    private LocalDate startDate = LocalDate.now().plusDays(7);
+    private LocalDate endDate = LocalDate.now().plusDays(9);
+    
+    public ReservationTestDataBuilder withName(String name) {
+        this.name = name;
+        return this;
+    }
+    
+    public ReservationTestDataBuilder withPhone(String phone) {
+        this.phone = phone;
+        return this;
+    }
+    
+    public ReservationTestDataBuilder withSiteNumber(String siteNumber) {
+        this.siteNumber = siteNumber;
+        return this;
+    }
+    
+    public ReservationTestDataBuilder withDates(LocalDate startDate, LocalDate endDate) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+        return this;
+    }
+    
+    public Map<String, Object> build() {
+        Map<String, Object> request = new HashMap<>();
+        request.put("siteNumber", siteNumber);
+        request.put("startDate", startDate.toString());
+        request.put("endDate", endDate.toString());
+        request.put("customerName", name);
+        request.put("phoneNumber", phone);
+        return request;
+    }
+}

--- a/src/test/java/com/camping/legacy/config/TestClockConfiguration.java
+++ b/src/test/java/com/camping/legacy/config/TestClockConfiguration.java
@@ -1,0 +1,20 @@
+package com.camping.legacy.config;
+
+import com.camping.legacy.common.ClockProvider;
+import com.camping.legacy.common.FixedClockProvider;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+
+import java.time.LocalDate;
+
+@TestConfiguration
+@Profile("test")
+public class TestClockConfiguration {
+    
+    @Bean
+    public ClockProvider clockProvider() {
+        // 테스트 환경에서 날짜를 12월 1일로 고정하여 12월 예약이 30일 이내 조건을 만족하도록 설정
+        return new FixedClockProvider(LocalDate.of(LocalDate.now().getYear(), 12, 1));
+    }
+}


### PR DESCRIPTION
안녕하세요, 브라운!
늦었지만 3단계 미션 구현 완료되어 리뷰 요청드립니다!

이번 미션에서는 이전 단계에서 발견된 버그를 수정하고, 누락된 비즈니스 로직(30일 이내 예약 제한 기능)을 추가하였습니다. 해당 기능과 수정된 버그는 테스트를 통해 정상 동작 확인하였습니다.

30일 이내 예약 제한 기능을 추가하면서 모든 테스트가 현재 날짜로부터 30일을 초과하게 되어 실패하는 문제가 있었습니다. 이걸 해결하기 위해 프로덕션 코드를 수정하게 되었는데요. Clock 추상화를 도입해서 테스트 환경에서는 시간을 제어할 수 있도록 구현했습니다. Slack 에도 질문을 남겼었지만 말씀하신 것처럼, 너무 완벽한 코드만을 추구하기 보다 시행 착오를 경험 해보고자 합니다!

테스트 코드의 중복을 개선하기 위해 헬퍼와 테스트 데이터 빌더를 도입하였습니다.
- ReservationTestBuilder: 날짜 관련 편의 메서드 추가
- ReservationApiHelper: API 호출 로직 캡슐화
- ConcurrencyTestHelpder: 동시성 테스트 중복 코드 개선

마지막으로 이번에 추가한 경계값 테스트, null/empty 값 테스트, 부분 겹침 예약 테스트 등은 인수 테스트 시나리오에 포함되지 않은 테스트들인데, 이러한 확장된 테스트 케이스들은 인수 테스트 시나리오에 추가되어야 하는 걸까요?