### PR TITLE
🚀 2단계 - 인수 테스트 구현

### DIFF
--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -135,7 +135,7 @@ class ReservationAcceptanceTest extends AcceptanceTest {
 ### 4.1 공통 설정 클래스
 
 ```java
-package com.camping.acceptance.common;
+package com.camping.legacy.common;
 
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
@@ -148,24 +148,24 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public abstract class AcceptanceTest {
 
-    @LocalServerPort
-    int port;
+  @LocalServerPort
+  int port;
 
-    @Autowired
-    private DatabaseCleanup databaseCleanup;
+  @Autowired
+  private DatabaseCleanup databaseCleanup;
 
-    @BeforeEach
-    void setUp() {
-        RestAssured.port = port;
-        databaseCleanup.execute();
-    }
+  @BeforeEach
+  void setUp() {
+    RestAssured.port = port;
+    databaseCleanup.execute();
+  }
 }
 ```
 
 ### 4.2 테스트 픽스처
 
 ```java
-package com.camping.acceptance.common;
+package com.camping.legacy.common;
 
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -176,59 +176,59 @@ import java.util.Map;
 
 public class TestFixture {
 
-    public static ExtractableResponse<Response> 사이트_등록_요청(String siteNumber, int maxPeople) {
-        Map<String, Object> params = new HashMap<>();
-        params.put("siteNumber", siteNumber);
-        params.put("description", siteNumber + " 사이트");
-        params.put("maxPeople", maxPeople);
+  public static ExtractableResponse<Response> 사이트_등록_요청(String siteNumber, int maxPeople) {
+    Map<String, Object> params = new HashMap<>();
+    params.put("siteNumber", siteNumber);
+    params.put("description", siteNumber + " 사이트");
+    params.put("maxPeople", maxPeople);
 
-        return RestAssured
-                .given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(params)
-                .when().post("/api/sites")
-                .then().log().all()
-                .extract();
-    }
+    return RestAssured
+        .given().log().all()
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(params)
+        .when().post("/api/sites")
+        .then().log().all()
+        .extract();
+  }
 
-    public static ExtractableResponse<Response> 예약_생성_요청(
-            String siteNumber, String startDate, String endDate,
-            String customerName, int numberOfPeople) {
+  public static ExtractableResponse<Response> 예약_생성_요청(
+      String siteNumber, String startDate, String endDate,
+      String customerName, int numberOfPeople) {
 
-        Map<String, Object> params = new HashMap<>();
-        params.put("siteNumber", siteNumber);
-        params.put("startDate", startDate);
-        params.put("endDate", endDate);
-        params.put("customerName", customerName);
-        params.put("numberOfPeople", numberOfPeople);
-        params.put("phoneNumber", "010-1234-5678");
+    Map<String, Object> params = new HashMap<>();
+    params.put("siteNumber", siteNumber);
+    params.put("startDate", startDate);
+    params.put("endDate", endDate);
+    params.put("customerName", customerName);
+    params.put("numberOfPeople", numberOfPeople);
+    params.put("phoneNumber", "010-1234-5678");
 
-        return RestAssured
-                .given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(params)
-                .when().post("/api/reservations")
-                .then().log().all()
-                .extract();
-    }
+    return RestAssured
+        .given().log().all()
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(params)
+        .when().post("/api/reservations")
+        .then().log().all()
+        .extract();
+  }
 
-    public static ExtractableResponse<Response> 예약_취소_요청(Long id, String confirmationCode) {
-        return RestAssured
-                .given().log().all()
-                .queryParam("confirmationCode", confirmationCode)
-                .when().delete("/api/reservations/{id}", id)
-                .then().log().all()
-                .extract();
-    }
+  public static ExtractableResponse<Response> 예약_취소_요청(Long id, String confirmationCode) {
+    return RestAssured
+        .given().log().all()
+        .queryParam("confirmationCode", confirmationCode)
+        .when().delete("/api/reservations/{id}", id)
+        .then().log().all()
+        .extract();
+  }
 }
 ```
 
 ### 4.3 예약 인수 테스트 (완전한 예시)
 
 ```java
-package com.camping.acceptance;
+package com.camping.legacy;
 
-import com.camping.acceptance.common.AcceptanceTest;
+import com.camping.legacy.common.AcceptanceTest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.BeforeEach;
@@ -237,7 +237,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
-import static com.camping.acceptance.common.TestFixture.*;
+import static com.camping.legacy.common.TestFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -248,68 +248,68 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("예약 생성 인수 테스트")
 class ReservationAcceptanceTest extends AcceptanceTest {
 
-    @BeforeEach
-    void setUpFixture() {
-        // Background: 사이트 "A-1"이 등록되어 있다
-        사이트_등록_요청("A-1", 6);
+  @BeforeEach
+  void setUpFixture() {
+    // Background: 사이트 "A-1"이 등록되어 있다
+    사이트_등록_요청("A-1", 6);
+  }
+
+  @Nested
+  @DisplayName("정상 케이스")
+  class HappyPath {
+
+    @Test
+    @DisplayName("[정상] 예약이 없는 기간에 정상적으로 예약 생성")
+    void 예약_생성_성공() {
+      // given - "A-1" 사이트의 해당 기간에 예약이 없다
+
+      // when - "김철수"가 예약을 요청한다
+      ExtractableResponse<Response> response = 예약_생성_요청(
+          "A-1", "2024-08-15", "2024-08-17", "김철수", 4
+      );
+
+      // then - 예약이 성공적으로 생성된다
+      assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+      assertThat(response.jsonPath().getString("confirmationCode")).hasSize(8);
+    }
+  }
+
+  @Nested
+  @DisplayName("예외 케이스")
+  class ExceptionCase {
+
+    @Test
+    @DisplayName("[예외] 동일 기간 동일 사이트 중복 예약 거부")
+    void 중복_예약_시도시_예외_발생() {
+      // given - "A-1" 사이트에 "홍길동"의 예약이 있다
+      예약_생성_요청("A-1", "2024-08-15", "2024-08-17", "홍길동", 4);
+
+      // when - "김철수"가 같은 기간에 예약 시도한다
+      ExtractableResponse<Response> response = 예약_생성_요청(
+          "A-1", "2024-08-15", "2024-08-17", "김철수", 4
+      );
+
+      // then - 예약이 거부된다
+      assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+      assertThat(response.jsonPath().getString("message"))
+          .isEqualTo("해당 기간에 이미 예약이 존재합니다");
     }
 
-    @Nested
-    @DisplayName("정상 케이스")
-    class HappyPath {
+    @Test
+    @DisplayName("[예외] 일부 기간이 겹치는 예약 거부")
+    void 기간_겹침_예약_시도시_예외_발생() {
+      // given - "A-1" 사이트에 예약이 있다 (8/15 ~ 8/17)
+      예약_생성_요청("A-1", "2024-08-15", "2024-08-17", "홍길동", 4);
 
-        @Test
-        @DisplayName("[정상] 예약이 없는 기간에 정상적으로 예약 생성")
-        void 예약_생성_성공() {
-            // given - "A-1" 사이트의 해당 기간에 예약이 없다
+      // when - 겹치는 기간에 예약 시도한다 (8/16 ~ 8/18)
+      ExtractableResponse<Response> response = 예약_생성_요청(
+          "A-1", "2024-08-16", "2024-08-18", "김철수", 4
+      );
 
-            // when - "김철수"가 예약을 요청한다
-            ExtractableResponse<Response> response = 예약_생성_요청(
-                    "A-1", "2024-08-15", "2024-08-17", "김철수", 4
-            );
-
-            // then - 예약이 성공적으로 생성된다
-            assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-            assertThat(response.jsonPath().getString("confirmationCode")).hasSize(8);
-        }
+      // then - 예약이 거부된다
+      assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
     }
-
-    @Nested
-    @DisplayName("예외 케이스")
-    class ExceptionCase {
-
-        @Test
-        @DisplayName("[예외] 동일 기간 동일 사이트 중복 예약 거부")
-        void 중복_예약_시도시_예외_발생() {
-            // given - "A-1" 사이트에 "홍길동"의 예약이 있다
-            예약_생성_요청("A-1", "2024-08-15", "2024-08-17", "홍길동", 4);
-
-            // when - "김철수"가 같은 기간에 예약 시도한다
-            ExtractableResponse<Response> response = 예약_생성_요청(
-                    "A-1", "2024-08-15", "2024-08-17", "김철수", 4
-            );
-
-            // then - 예약이 거부된다
-            assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
-            assertThat(response.jsonPath().getString("message"))
-                    .isEqualTo("해당 기간에 이미 예약이 존재합니다");
-        }
-
-        @Test
-        @DisplayName("[예외] 일부 기간이 겹치는 예약 거부")
-        void 기간_겹침_예약_시도시_예외_발생() {
-            // given - "A-1" 사이트에 예약이 있다 (8/15 ~ 8/17)
-            예약_생성_요청("A-1", "2024-08-15", "2024-08-17", "홍길동", 4);
-
-            // when - 겹치는 기간에 예약 시도한다 (8/16 ~ 8/18)
-            ExtractableResponse<Response> response = 예약_생성_요청(
-                    "A-1", "2024-08-16", "2024-08-18", "김철수", 4
-            );
-
-            // then - 예약이 거부된다
-            assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
-        }
-    }
+  }
 }
 ```
 

--- a/docs/sql-vs-databasecleanup.md
+++ b/docs/sql-vs-databasecleanup.md
@@ -1,0 +1,270 @@
+# @Sql vs DatabaseCleanup
+
+인수 테스트에서 테스트 데이터 격리를 위한 두 가지 방식 비교
+
+## 코드 비교
+
+### @Sql 방식
+
+```java
+@Sql(scripts = "/sql/cleanup.sql", executionPhase = BEFORE_TEST_METHOD)
+@Sql(scripts = "/sql/init-sites.sql", executionPhase = BEFORE_TEST_METHOD)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public abstract class AcceptanceTest {
+
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+}
+```
+
+```sql
+-- src/test/resources/sql/cleanup.sql
+SET REFERENTIAL_INTEGRITY FALSE;
+TRUNCATE TABLE reservations;
+TRUNCATE TABLE campsites;
+SET REFERENTIAL_INTEGRITY TRUE;
+```
+
+```sql
+-- src/test/resources/sql/init-sites.sql
+INSERT INTO campsites (site_number, description, max_people) VALUES
+('A-1', '대형 사이트 - 전기 있음', 6),
+('A-2', '대형 사이트 - 전기 있음', 6),
+('A-3', '대형 사이트 - 전기 있음', 6),
+('B-1', '소형 사이트 - 전기 있음', 4),
+('B-2', '소형 사이트 - 전기 있음', 4);
+```
+
+### DatabaseCleanup 방식
+
+```java
+@Import(DatabaseCleanup.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public abstract class AcceptanceTest {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    private DatabaseCleanup databaseCleanup;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        databaseCleanup.execute();
+    }
+}
+```
+
+```java
+// DatabaseCleanup.java
+package com.camping.legacy.common;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Table;
+import jakarta.persistence.metamodel.EntityType;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class DatabaseCleanup {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private List<String> tableNames;
+
+    @Transactional
+    public void execute() {
+        entityManager.flush();
+
+        // 외래키 제약 조건 비활성화하여 삭제 순서 무시
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+
+        for (String tableName : getTableNames()) {
+            // 테이블 데이터 전체 삭제
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+            // ID 자동증가값을 1부터 다시 시작
+            entityManager.createNativeQuery(
+                    "ALTER TABLE " + tableName + " ALTER COLUMN ID RESTART WITH 1"
+            ).executeUpdate();
+        }
+        // 외래키 제약조건 다시 활성화
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+
+        // 기본 사이트 데이터 복원
+        insertDefaultSites();
+    }
+
+    private void insertDefaultSites() {
+        entityManager.createNativeQuery(
+                "INSERT INTO campsites (site_number, description, max_people) VALUES " +
+                        "('A-1', '대형 사이트 - 전기 있음', 6), " +
+                        "('A-2', '대형 사이트 - 전기 있음', 6), " +
+                        "('A-3', '대형 사이트 - 전기 있음', 6), " +
+                        "('B-1', '소형 사이트 - 전기 있음', 4), " +
+                        "('B-2', '소형 사이트 - 전기 있음', 4)"
+        ).executeUpdate();
+    }
+
+    private List<String> getTableNames() {
+        if (tableNames == null) {
+            tableNames = entityManager.getMetamodel().getEntities().stream()
+                    .filter(e -> e.getJavaType().getAnnotation(Entity.class) != null)
+                    .map(this::getTableName)
+                    .collect(Collectors.toList());
+        }
+        return tableNames;
+    }
+
+    private String getTableName(EntityType<?> entity) {
+        Table tableAnnotation = entity.getJavaType().getAnnotation(Table.class);
+        return tableAnnotation != null ? tableAnnotation.name() : entity.getName();
+    }
+}
+```
+
+## 장단점 비교
+
+| 항목 | @Sql | DatabaseCleanup |
+|------|------|-----------------|
+| **Spring 표준** | O | X (커스텀) |
+| **선언적** | O (어노테이션) | X (코드) |
+| **유연성** | X (정적 SQL) | O (동적 처리) |
+| **테이블 추가 시** | SQL 수정 필요 | 자동 감지 |
+| **DB 변경 시** | SQL 문법 수정 필요 | 일부 수정 필요 |
+| **디버깅** | SQL 파일로 명확 | 코드 추적 필요 |
+| **재사용성** | 프로젝트별 SQL 필요 | 공통 클래스 복사 가능 |
+
+## 엔티티 추가 시 시나리오
+
+새 엔티티가 추가된 경우:
+
+```java
+@Entity
+public class Payment { ... }
+```
+
+### @Sql 방식
+`cleanup.sql`에 수동으로 추가 필요:
+```sql
+TRUNCATE TABLE payments;
+```
+
+### DatabaseCleanup 방식
+자동으로 처리됨 (EntityManager가 엔티티 메타데이터에서 감지)
+
+## 추천 가이드
+
+| 상황 | 추천 방식 |
+|------|----------|
+| 테이블 구조가 자주 바뀜 | DatabaseCleanup |
+| 테이블 구조가 안정적 | @Sql |
+| Spring 표준 선호 | @Sql |
+| 여러 프로젝트에서 재사용 | DatabaseCleanup |
+
+
+## @DirtiesContext
+
+Spring 컨텍스트를 "더럽혀졌다"고 표시해서 재생성하게 하는 어노테이션입니다.
+
+### 사용 예시
+
+```java
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+class MyTest {
+
+    @Test
+    void 테스트1() { }  // 테스트 후 컨텍스트 재생성
+
+    @Test
+    void 테스트2() { }  // 테스트 후 컨텍스트 재생성
+}
+```
+
+### 동작 방식
+
+```
+테스트1 실행
+    ↓
+컨텍스트 파괴 & 재생성 (DB도 초기화됨)
+    ↓
+테스트2 실행
+    ↓
+컨텍스트 파괴 & 재생성
+    ...
+```
+
+### 장단점
+
+| 장점 | 단점 |
+|------|------|
+| 확실한 격리 | **매우 느림** |
+| 코드 간단 | 테스트 10개면 컨텍스트 10번 재생성 |
+| 설정 간편 | 컨텍스트 로딩에 2-5초씩 걸림 |
+
+### 성능 비교
+
+```
+DatabaseCleanup: 테스트 10개 → 약 10초
+@DirtiesContext: 테스트 10개 → 약 30-50초
+```
+
+테스트가 많아질수록 차이가 기하급수적으로 커집니다.
+
+### 언제 사용하나?
+
+- 테스트가 **전역 상태를 변경**할 때 (예: static 변수, 싱글톤 캐시)
+- **특정 테스트만** 컨텍스트를 오염시킬 때
+- 테스트 개수가 **매우 적을 때**
+
+```java
+// 이런 경우에만 사용
+@Test
+@DirtiesContext
+void 캐시를_완전히_비우는_테스트() {
+    cacheManager.clearAll();  // 전역 상태 변경
+}
+```
+
+## @Transactional을 인수 테스트에서 사용할 수 없는 이유
+
+```
+[테스트 스레드]                    [서버 스레드]
+@Transactional
+  |
+  | 예약_생성_요청() ──────────→  POST /api/reservations
+  |                                |
+  |                              DB INSERT (커밋됨!)
+  |
+  | 롤백 시도
+  └─→ 이미 서버에서 커밋됨 → 롤백 안 됨
+```
+
+RestAssured는 실제 HTTP 요청을 보내고, 서버는 별도 트랜잭션에서 실행됩니다.
+테스트 트랜잭션을 롤백해도 서버 트랜잭션은 이미 커밋된 상태입니다.
+
+## 전체 비교표
+
+| 방식 | 속도 | 인수테스트 적합 | 특징 |
+|------|------|----------------|------|
+| **DatabaseCleanup** | 빠름 | O | 동적 테이블 감지 |
+| **@Sql** | 빠름 | O | Spring 표준, 선언적 |
+| **@Transactional** | 빠름 | X | 트랜잭션 분리 문제 |
+| **@DirtiesContext** | 매우 느림 | O | 컨텍스트 재생성 |
+
+## 결론
+
+- **인수 테스트(E2E)**: `DatabaseCleanup` 또는 `@Sql` 사용
+- **통합 테스트**: `@Transactional` 사용 가능
+- **단위 테스트**: 모킹 사용

--- a/src/test/java/com/camping/legacy/CalendarAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/CalendarAcceptanceTest.java
@@ -1,0 +1,113 @@
+package com.camping.legacy;
+
+import com.camping.legacy.common.AcceptanceTest;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static com.camping.legacy.common.CalendarAssertions.*;
+import static com.camping.legacy.common.ReservationAssertions.*;
+import static com.camping.legacy.common.TestFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Feature: 취소된 예약 캘린더 제외
+ *
+ * @see docs/4.scenarios.feature - "취소된 예약 캘린더 제외" Feature 참조
+ */
+@DisplayName("캘린더 조회 인수 테스트")
+class CalendarAcceptanceTest extends AcceptanceTest {
+
+    private static final int JANUARY_DAYS = 31;
+
+    private Long siteId;
+
+    @BeforeEach
+    void setUpFixture() {
+        // Background: 사이트 "A-1"이 등록되어 있다 (DatabaseCleanup에서 기본 데이터 복원됨)
+        siteId = 사이트_ID_조회("A-1");
+    }
+
+    @Nested
+    @DisplayName("정상 케이스")
+    class HappyPath {
+
+        @Test
+        @DisplayName("[정상] 취소된 예약은 캘린더에서 이용 가능으로 표시")
+        void 취소된_예약_이용가능_표시() {
+            // given - "A-1" 사이트에 취소된 예약이 있다
+            ExtractableResponse<Response> 예약_응답 = 예약_생성_요청(
+                    "A-1", "2026-01-20", "2026-01-22", "홍길동", 4);
+            Long 예약_id = 예약_응답.jsonPath().getLong("id");
+            String 확인코드 = 예약_응답.jsonPath().getString("confirmationCode");
+            예약_취소_요청(예약_id, 확인코드);
+
+            // when - 관리자가 캘린더를 조회한다
+            ExtractableResponse<Response> response = 캘린더_조회_요청(siteId, 2026, 1);
+
+            // then - 해당 날짜들은 "이용 가능" 상태이다
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+            날짜가_예약가능_검증(response, "2026-01-20", "2026-01-21");
+        }
+
+        @Test
+        @DisplayName("[정상] 취소된 날짜에 새로운 예약 가능")
+        void 취소된_날짜_재예약_성공() {
+            // given - "A-1" 사이트에 취소된 예약이 있다
+            ExtractableResponse<Response> 예약_응답 = 예약_생성_요청(
+                    "A-1", "2026-01-20", "2026-01-22", "홍길동", 4);
+            Long 예약_id = 예약_응답.jsonPath().getLong("id");
+            String 확인코드 = 예약_응답.jsonPath().getString("confirmationCode");
+            예약_취소_요청(예약_id, 확인코드);
+
+            // when - 취소된 날짜에 새로운 예약을 요청한다
+            ExtractableResponse<Response> 재예약_응답 = 예약_생성_요청(
+                    "A-1", "2026-01-20", "2026-01-22", "김철수", 3);
+
+            // then - 예약이 성공적으로 생성된다
+            예약_생성_성공_검증(재예약_응답, "김철수");
+        }
+
+        @Test
+        @DisplayName("[정상] 확정된 예약만 캘린더에 예약됨으로 표시")
+        void 확정_예약만_캘린더_표시() {
+            // given - 확정된 예약과 취소된 예약이 혼재한다
+            예약_생성_요청("A-1", "2026-01-10", "2026-01-12", "홍길동", 4);
+
+            ExtractableResponse<Response> 취소할_예약 = 예약_생성_요청(
+                    "A-1", "2026-01-20", "2026-01-22", "김철수", 3);
+            Long 예약_id = 취소할_예약.jsonPath().getLong("id");
+            String 확인코드 = 취소할_예약.jsonPath().getString("confirmationCode");
+            예약_취소_요청(예약_id, 확인코드);
+
+            // when - 관리자가 캘린더를 조회한다
+            ExtractableResponse<Response> response = 캘린더_조회_요청(siteId, 2026, 1);
+
+            // then - 확정된 예약만 "예약됨" 상태로 표시된다
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+            날짜가_예약됨_검증(response, "2026-01-10", "2026-01-11");
+
+            // and - 취소된 예약은 "이용 가능" 상태로 표시된다
+            날짜가_예약가능_검증(response, "2026-01-20", "2026-01-21");
+        }
+
+        @Test
+        @DisplayName("[정상] 월별 캘린더 전체 조회")
+        void 월별_캘린더_전체_조회() {
+            // given - 사이트에 예약이 있다
+            예약_생성_요청("A-1", "2026-01-15", "2026-01-17", "홍길동", 4);
+
+            // when - 관리자가 월별 캘린더를 조회한다
+            ExtractableResponse<Response> response = 캘린더_조회_요청(siteId, 2026, 1);
+
+            // then - 해당 월의 모든 날짜 현황이 반환된다
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+            캘린더_기본정보_검증(response, 2026, 1, siteId);
+            월별_날짜수_검증(response, JANUARY_DAYS);
+        }
+    }
+}

--- a/src/test/java/com/camping/legacy/CalendarAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/CalendarAcceptanceTest.java
@@ -22,14 +22,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("캘린더 조회 인수 테스트")
 class CalendarAcceptanceTest extends AcceptanceTest {
 
-    private static final int JANUARY_DAYS = 31;
-
     private Long siteId;
+    private int testYear;
+    private int testMonth;
+    private int testMonthDays;
 
     @BeforeEach
     void setUpFixture() {
         // Background: 사이트 "A-1"이 등록되어 있다 (DatabaseCleanup에서 기본 데이터 복원됨)
         siteId = 사이트_ID_조회("A-1");
+        testYear = 다음달_연도();
+        testMonth = 다음달_월();
+        testMonthDays = 다음달_일수();
     }
 
     @Nested
@@ -41,17 +45,17 @@ class CalendarAcceptanceTest extends AcceptanceTest {
         void 취소된_예약_이용가능_표시() {
             // given - "A-1" 사이트에 취소된 예약이 있다
             ExtractableResponse<Response> 예약_응답 = 예약_생성_요청(
-                    "A-1", "2026-01-20", "2026-01-22", "홍길동", 4);
+                    "A-1", 다음달_일자(20), 다음달_일자(22), "홍길동", 4);
             Long 예약_id = 예약_응답.jsonPath().getLong("id");
             String 확인코드 = 예약_응답.jsonPath().getString("confirmationCode");
             예약_취소_요청(예약_id, 확인코드);
 
             // when - 관리자가 캘린더를 조회한다
-            ExtractableResponse<Response> response = 캘린더_조회_요청(siteId, 2026, 1);
+            ExtractableResponse<Response> response = 캘린더_조회_요청(siteId, testYear, testMonth);
 
             // then - 해당 날짜들은 "이용 가능" 상태이다
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-            날짜가_예약가능_검증(response, "2026-01-20", "2026-01-21");
+            날짜가_예약가능_검증(response, 다음달_일자(20), 다음달_일자(21));
         }
 
         @Test
@@ -59,14 +63,14 @@ class CalendarAcceptanceTest extends AcceptanceTest {
         void 취소된_날짜_재예약_성공() {
             // given - "A-1" 사이트에 취소된 예약이 있다
             ExtractableResponse<Response> 예약_응답 = 예약_생성_요청(
-                    "A-1", "2026-01-20", "2026-01-22", "홍길동", 4);
+                    "A-1", 다음달_일자(20), 다음달_일자(22), "홍길동", 4);
             Long 예약_id = 예약_응답.jsonPath().getLong("id");
             String 확인코드 = 예약_응답.jsonPath().getString("confirmationCode");
             예약_취소_요청(예약_id, 확인코드);
 
             // when - 취소된 날짜에 새로운 예약을 요청한다
             ExtractableResponse<Response> 재예약_응답 = 예약_생성_요청(
-                    "A-1", "2026-01-20", "2026-01-22", "김철수", 3);
+                    "A-1", 다음달_일자(20), 다음달_일자(22), "김철수", 3);
 
             // then - 예약이 성공적으로 생성된다
             예약_생성_성공_검증(재예약_응답, "김철수");
@@ -76,38 +80,38 @@ class CalendarAcceptanceTest extends AcceptanceTest {
         @DisplayName("[정상] 확정된 예약만 캘린더에 예약됨으로 표시")
         void 확정_예약만_캘린더_표시() {
             // given - 확정된 예약과 취소된 예약이 혼재한다
-            예약_생성_요청("A-1", "2026-01-10", "2026-01-12", "홍길동", 4);
+            예약_생성_요청("A-1", 다음달_일자(10), 다음달_일자(12), "홍길동", 4);
 
             ExtractableResponse<Response> 취소할_예약 = 예약_생성_요청(
-                    "A-1", "2026-01-20", "2026-01-22", "김철수", 3);
+                    "A-1", 다음달_일자(20), 다음달_일자(22), "김철수", 3);
             Long 예약_id = 취소할_예약.jsonPath().getLong("id");
             String 확인코드 = 취소할_예약.jsonPath().getString("confirmationCode");
             예약_취소_요청(예약_id, 확인코드);
 
             // when - 관리자가 캘린더를 조회한다
-            ExtractableResponse<Response> response = 캘린더_조회_요청(siteId, 2026, 1);
+            ExtractableResponse<Response> response = 캘린더_조회_요청(siteId, testYear, testMonth);
 
             // then - 확정된 예약만 "예약됨" 상태로 표시된다
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-            날짜가_예약됨_검증(response, "2026-01-10", "2026-01-11");
+            날짜가_예약됨_검증(response, 다음달_일자(10), 다음달_일자(11));
 
             // and - 취소된 예약은 "이용 가능" 상태로 표시된다
-            날짜가_예약가능_검증(response, "2026-01-20", "2026-01-21");
+            날짜가_예약가능_검증(response, 다음달_일자(20), 다음달_일자(21));
         }
 
         @Test
         @DisplayName("[정상] 월별 캘린더 전체 조회")
         void 월별_캘린더_전체_조회() {
             // given - 사이트에 예약이 있다
-            예약_생성_요청("A-1", "2026-01-15", "2026-01-17", "홍길동", 4);
+            예약_생성_요청("A-1", 다음달_일자(15), 다음달_일자(17), "홍길동", 4);
 
             // when - 관리자가 월별 캘린더를 조회한다
-            ExtractableResponse<Response> response = 캘린더_조회_요청(siteId, 2026, 1);
+            ExtractableResponse<Response> response = 캘린더_조회_요청(siteId, testYear, testMonth);
 
             // then - 해당 월의 모든 날짜 현황이 반환된다
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-            캘린더_기본정보_검증(response, 2026, 1, siteId);
-            월별_날짜수_검증(response, JANUARY_DAYS);
+            캘린더_기본정보_검증(response, testYear, testMonth, siteId);
+            월별_날짜수_검증(response, testMonthDays);
         }
     }
 }

--- a/src/test/java/com/camping/legacy/ReservationAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/ReservationAcceptanceTest.java
@@ -1,0 +1,140 @@
+package com.camping.legacy;
+
+import com.camping.legacy.common.AcceptanceTest;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.camping.legacy.common.ReservationAssertions.*;
+import static com.camping.legacy.common.TestFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Feature: 중복 예약 방지
+ *
+ * @see docs/4.scenarios.feature - "중복 예약 방지" Feature 참조
+ */
+@DisplayName("예약 생성 인수 테스트")
+class ReservationAcceptanceTest extends AcceptanceTest {
+
+    @BeforeEach
+    void setUpFixture() {
+        // Background: 사이트 "A-1"이 등록되어 있다 (DatabaseCleanup에서 기본 데이터 복원됨)
+    }
+
+    @Nested
+    @DisplayName("정상 케이스")
+    class HappyPath {
+
+        @Test
+        @DisplayName("[정상] 예약이 없는 기간에 정상적으로 예약 생성")
+        void 예약_생성_성공() {
+            // given - "A-1" 사이트의 해당 기간에 예약이 없다
+
+            // when - "김철수"가 예약을 요청한다
+            ExtractableResponse<Response> response = 예약_생성_요청(
+                    "A-1", "2026-01-01", "2026-01-18", "김철수", 4
+            );
+
+            // then - 예약이 성공적으로 생성된다
+            예약_생성_성공_검증(response, "김철수");
+        }
+
+        @Test
+        @DisplayName("[정상] 다른 사이트는 동일 기간에 예약 가능")
+        void 다른_사이트_동일_기간_예약_성공() {
+            // given - 사이트 "B-1"이 등록되어 있다 (DatabaseCleanup에서 기본 데이터 복원됨)
+            // and - "A-1" 사이트에 "홍길동"의 예약이 있다
+            예약_생성_요청("A-1", "2026-01-01", "2026-01-18", "홍길동", 4);
+
+            // when - "김철수"가 "B-1" 사이트를 같은 기간에 예약 요청한다
+            ExtractableResponse<Response> response = 예약_생성_요청(
+                    "B-1", "2026-01-01", "2026-01-18", "김철수", 4
+            );
+
+            // then - 예약이 성공적으로 생성된다
+            예약_생성_성공_검증(response, "김철수");
+        }
+    }
+
+    @Nested
+    @DisplayName("예외 케이스")
+    class ExceptionCase {
+
+        @Test
+        @DisplayName("[예외] 동일 기간 동일 사이트 중복 예약 거부")
+        void 중복_예약_시도시_예외_발생() {
+            // given - "A-1" 사이트에 "홍길동"의 예약이 있다
+            예약_생성_요청("A-1", "2026-01-01", "2026-01-18", "홍길동", 4);
+
+            // when - "김철수"가 같은 기간에 예약 시도한다
+            ExtractableResponse<Response> response = 예약_생성_요청(
+                    "A-1", "2026-01-01", "2026-01-18", "김철수", 4
+            );
+
+            // then - 예약이 거부된다
+            // and - 오류 메시지 "해당 기간에 이미 예약이 존재합니다"가 반환된다
+            예약_충돌_오류_검증(response);
+        }
+
+        @Test
+        @DisplayName("[예외] 일부 기간이 겹치는 예약 거부")
+        void 기간_겹침_예약_시도시_예외_발생() {
+            // given - "A-1" 사이트에 예약이 있다 (1/10 ~ 1/15)
+            예약_생성_요청("A-1", "2026-01-10", "2026-01-15", "홍길동", 4);
+
+            // when - 겹치는 기간에 예약 시도한다 (1/14 ~ 1/18)
+            ExtractableResponse<Response> response = 예약_생성_요청(
+                    "A-1", "2026-01-14", "2026-01-18", "김철수", 4
+            );
+
+            // then - 예약이 거부된다
+            예약_충돌_오류_검증(response);
+        }
+
+        @Test
+        @DisplayName("[예외] 동시 예약 요청 시 하나만 성공")
+        void 동시_예약_요청시_하나만_성공() throws InterruptedException {
+            // given - "A-1" 사이트의 해당 기간에 예약이 없다
+            int threadCount = 2;
+            CountDownLatch latch = new CountDownLatch(threadCount);
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+
+            // when - "김철수"와 "이영희"가 동시에 같은 기간을 예약 요청한다
+            Runnable task = () -> {
+                try {
+                    ExtractableResponse<Response> response = 예약_생성_요청(
+                            "A-1", "2026-02-01", "2026-02-05", "고객", 4
+                    );
+                    if (response.statusCode() == HttpStatus.CREATED.value()) {
+                        successCount.incrementAndGet();
+                    } else {
+                        failCount.incrementAndGet();
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            };
+
+            new Thread(task).start();
+            new Thread(task).start();
+            latch.await();
+
+            // then - 하나의 예약만 성공한다
+            assertThat(successCount.get())
+                    .as("동시 요청 시 하나만 성공해야 합니다")
+                    .isEqualTo(1);
+            assertThat(failCount.get())
+                    .as("동시 요청 시 하나는 실패해야 합니다")
+                    .isEqualTo(1);
+        }
+    }
+}

--- a/src/test/java/com/camping/legacy/ReservationAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/ReservationAcceptanceTest.java
@@ -26,7 +26,7 @@ class ReservationAcceptanceTest extends AcceptanceTest {
 
     @BeforeEach
     void setUpFixture() {
-        // Background: 사이트 "A-1"이 등록되어 있다 (DatabaseCleanup에서 기본 데이터 복원됨)
+      // Background: 사이트 "A-1"이 등록되어 있다 (DatabaseCleanup에서 기본 데이터 복원됨)
     }
 
     @Nested
@@ -40,7 +40,7 @@ class ReservationAcceptanceTest extends AcceptanceTest {
 
             // when - "김철수"가 예약을 요청한다
             ExtractableResponse<Response> response = 예약_생성_요청(
-                    "A-1", "2026-01-01", "2026-01-18", "김철수", 4
+                    "A-1", 오늘부터_N일_후(30), 오늘부터_N일_후(32), "김철수", 4
             );
 
             // then - 예약이 성공적으로 생성된다
@@ -52,11 +52,11 @@ class ReservationAcceptanceTest extends AcceptanceTest {
         void 다른_사이트_동일_기간_예약_성공() {
             // given - 사이트 "B-1"이 등록되어 있다 (DatabaseCleanup에서 기본 데이터 복원됨)
             // and - "A-1" 사이트에 "홍길동"의 예약이 있다
-            예약_생성_요청("A-1", "2026-01-01", "2026-01-18", "홍길동", 4);
+            예약_생성_요청("A-1", 오늘부터_N일_후(10), 오늘부터_N일_후(12), "홍길동", 4);
 
             // when - "김철수"가 "B-1" 사이트를 같은 기간에 예약 요청한다
             ExtractableResponse<Response> response = 예약_생성_요청(
-                    "B-1", "2026-01-01", "2026-01-18", "김철수", 4
+                    "B-1", 오늘부터_N일_후(10), 오늘부터_N일_후(12), "김철수", 4
             );
 
             // then - 예약이 성공적으로 생성된다
@@ -72,11 +72,11 @@ class ReservationAcceptanceTest extends AcceptanceTest {
         @DisplayName("[예외] 동일 기간 동일 사이트 중복 예약 거부")
         void 중복_예약_시도시_예외_발생() {
             // given - "A-1" 사이트에 "홍길동"의 예약이 있다
-            예약_생성_요청("A-1", "2026-01-01", "2026-01-18", "홍길동", 4);
+            예약_생성_요청("A-1", 오늘부터_N일_후(15), 오늘부터_N일_후(17), "홍길동", 4);
 
             // when - "김철수"가 같은 기간에 예약 시도한다
             ExtractableResponse<Response> response = 예약_생성_요청(
-                    "A-1", "2026-01-01", "2026-01-18", "김철수", 4
+                    "A-1", 오늘부터_N일_후(15), 오늘부터_N일_후(17), "김철수", 4
             );
 
             // then - 예약이 거부된다
@@ -87,12 +87,12 @@ class ReservationAcceptanceTest extends AcceptanceTest {
         @Test
         @DisplayName("[예외] 일부 기간이 겹치는 예약 거부")
         void 기간_겹침_예약_시도시_예외_발생() {
-            // given - "A-1" 사이트에 예약이 있다 (1/10 ~ 1/15)
-            예약_생성_요청("A-1", "2026-01-10", "2026-01-15", "홍길동", 4);
+            // given - "A-1" 사이트에 예약이 있다 (N+20 ~ N+25)
+            예약_생성_요청("A-1", 오늘부터_N일_후(20), 오늘부터_N일_후(25), "홍길동", 4);
 
-            // when - 겹치는 기간에 예약 시도한다 (1/14 ~ 1/18)
+            // when - 겹치는 기간에 예약 시도한다 (N+24 ~ N+28)
             ExtractableResponse<Response> response = 예약_생성_요청(
-                    "A-1", "2026-01-14", "2026-01-18", "김철수", 4
+                    "A-1", 오늘부터_N일_후(24), 오늘부터_N일_후(28), "김철수", 4
             );
 
             // then - 예약이 거부된다
@@ -108,11 +108,14 @@ class ReservationAcceptanceTest extends AcceptanceTest {
             AtomicInteger successCount = new AtomicInteger(0);
             AtomicInteger failCount = new AtomicInteger(0);
 
+            String startDate = 오늘부터_N일_후(40);
+            String endDate = 오늘부터_N일_후(45);
+
             // when - "김철수"와 "이영희"가 동시에 같은 기간을 예약 요청한다
             Runnable task = () -> {
                 try {
                     ExtractableResponse<Response> response = 예약_생성_요청(
-                            "A-1", "2026-02-01", "2026-02-05", "고객", 4
+                            "A-1", startDate, endDate, "고객", 4
                     );
                     if (response.statusCode() == HttpStatus.CREATED.value()) {
                         successCount.incrementAndGet();

--- a/src/test/java/com/camping/legacy/ReservationModificationAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/ReservationModificationAcceptanceTest.java
@@ -26,7 +26,7 @@ class ReservationModificationAcceptanceTest extends AcceptanceTest {
     void setUpFixture() {
         // Background: 사이트와 예약이 존재한다 (DatabaseCleanup에서 기본 데이터 복원됨)
         ExtractableResponse<Response> response = 예약_생성_요청(
-                "A-1", "2026-08-10", "2026-08-12", "홍길동", 4
+                "A-1", 오늘부터_N일_후(50), 오늘부터_N일_후(52), "홍길동", 4
         );
         reservationId = response.jsonPath().getLong("id");
         confirmationCode = response.jsonPath().getString("confirmationCode");
@@ -40,16 +40,18 @@ class ReservationModificationAcceptanceTest extends AcceptanceTest {
         @DisplayName("[정상] 확정된(CONFIRMED) 예약은 수정 가능")
         void 확정_예약_수정_성공() {
             // given - 확인 코드가 있는 예약이 존재한다 (CONFIRMED 상태)
+            String newStartDate = 오늘부터_N일_후(55);
+            String newEndDate = 오늘부터_N일_후(57);
 
             // when - 날짜 변경을 요청한다
             ExtractableResponse<Response> response = 예약_수정_요청(
                     reservationId, confirmationCode,
-                    "2026-08-15", "2026-08-17"
+                    newStartDate, newEndDate
             );
 
             // then - 수정이 성공한다
             // and - 변경된 기간에 맞는 새로운 가격이 계산된다
-            예약_수정_성공_검증(response, "2026-08-15", "2026-08-17");
+            예약_수정_성공_검증(response, newStartDate, newEndDate);
         }
     }
 
@@ -66,7 +68,7 @@ class ReservationModificationAcceptanceTest extends AcceptanceTest {
             // when - 취소된 예약에 날짜 변경을 요청한다
             ExtractableResponse<Response> response = 예약_수정_요청(
                     reservationId, confirmationCode,
-                    "2026-08-20", "2026-08-22"
+                    오늘부터_N일_후(60), 오늘부터_N일_후(62)
             );
 
             // then - 수정이 거부된다
@@ -79,7 +81,7 @@ class ReservationModificationAcceptanceTest extends AcceptanceTest {
         void 당일취소_예약_수정_시도시_실패() {
             // given - 오늘 시작하는 예약을 생성하고 취소한다 (당일 취소 = CANCELLED_SAME_DAY)
             ExtractableResponse<Response> 오늘_예약 = 예약_생성_요청(
-                    "A-2", "2026-01-18", "2026-01-20", "김철수", 2
+                    "A-2", 오늘(), 오늘부터_N일_후(2), "김철수", 2
             );
             Long 오늘_예약_id = 오늘_예약.jsonPath().getLong("id");
             String 오늘_예약_확인코드 = 오늘_예약.jsonPath().getString("confirmationCode");
@@ -88,7 +90,7 @@ class ReservationModificationAcceptanceTest extends AcceptanceTest {
             // when - 수정을 요청한다
             ExtractableResponse<Response> response = 예약_수정_요청(
                     오늘_예약_id, 오늘_예약_확인코드,
-                    "2026-08-25", "2026-08-27"
+                    오늘부터_N일_후(65), 오늘부터_N일_후(67)
             );
 
             // then - 수정이 거부된다
@@ -99,12 +101,14 @@ class ReservationModificationAcceptanceTest extends AcceptanceTest {
         @DisplayName("[예외] 수정 시 다른 예약과 충돌하면 거부")
         void 수정시_다른_예약과_충돌_실패() {
             // given - 다른 예약이 존재한다
-            예약_생성_요청("A-1", "2026-08-20", "2026-08-22", "김철수", 3);
+            String conflictStart = 오늘부터_N일_후(70);
+            String conflictEnd = 오늘부터_N일_후(72);
+            예약_생성_요청("A-1", conflictStart, conflictEnd, "김철수", 3);
 
             // when - 충돌하는 날짜로 변경을 요청한다
             ExtractableResponse<Response> response = 예약_수정_요청(
                     reservationId, confirmationCode,
-                    "2026-08-20", "2026-08-22"
+                    conflictStart, conflictEnd
             );
 
             // then - 수정이 거부된다

--- a/src/test/java/com/camping/legacy/ReservationModificationAcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/ReservationModificationAcceptanceTest.java
@@ -1,0 +1,114 @@
+package com.camping.legacy;
+
+import com.camping.legacy.common.AcceptanceTest;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static com.camping.legacy.common.ReservationAssertions.*;
+import static com.camping.legacy.common.TestFixture.*;
+
+/**
+ * Feature: 취소된 예약 수정 방지
+ *
+ * @see docs/4.scenarios.feature - "취소된 예약 수정 방지" Feature 참조
+ */
+@DisplayName("예약 수정 인수 테스트")
+class ReservationModificationAcceptanceTest extends AcceptanceTest {
+
+    private Long reservationId;
+    private String confirmationCode;
+
+    @BeforeEach
+    void setUpFixture() {
+        // Background: 사이트와 예약이 존재한다 (DatabaseCleanup에서 기본 데이터 복원됨)
+        ExtractableResponse<Response> response = 예약_생성_요청(
+                "A-1", "2026-08-10", "2026-08-12", "홍길동", 4
+        );
+        reservationId = response.jsonPath().getLong("id");
+        confirmationCode = response.jsonPath().getString("confirmationCode");
+    }
+
+    @Nested
+    @DisplayName("정상 케이스")
+    class HappyPath {
+
+        @Test
+        @DisplayName("[정상] 확정된(CONFIRMED) 예약은 수정 가능")
+        void 확정_예약_수정_성공() {
+            // given - 확인 코드가 있는 예약이 존재한다 (CONFIRMED 상태)
+
+            // when - 날짜 변경을 요청한다
+            ExtractableResponse<Response> response = 예약_수정_요청(
+                    reservationId, confirmationCode,
+                    "2026-08-15", "2026-08-17"
+            );
+
+            // then - 수정이 성공한다
+            // and - 변경된 기간에 맞는 새로운 가격이 계산된다
+            예약_수정_성공_검증(response, "2026-08-15", "2026-08-17");
+        }
+    }
+
+    @Nested
+    @DisplayName("예외 케이스")
+    class ExceptionCase {
+
+        @Test
+        @DisplayName("[예외] 취소된(CANCELLED) 예약 수정 시도 거부")
+        void 취소된_예약_수정_시도시_실패() {
+            // given - 예약이 취소된 상태이다
+            예약_취소_요청(reservationId, confirmationCode);
+
+            // when - 취소된 예약에 날짜 변경을 요청한다
+            ExtractableResponse<Response> response = 예약_수정_요청(
+                    reservationId, confirmationCode,
+                    "2026-08-20", "2026-08-22"
+            );
+
+            // then - 수정이 거부된다
+            // and - 오류 메시지 "취소된 예약은 수정할 수 없습니다"가 반환된다
+            취소된_예약_수정_거부_검증(response);
+        }
+
+        @Test
+        @DisplayName("[예외] 당일 취소된(CANCELLED_SAME_DAY) 예약 수정 시도 거부")
+        void 당일취소_예약_수정_시도시_실패() {
+            // given - 오늘 시작하는 예약을 생성하고 취소한다 (당일 취소 = CANCELLED_SAME_DAY)
+            ExtractableResponse<Response> 오늘_예약 = 예약_생성_요청(
+                    "A-2", "2026-01-18", "2026-01-20", "김철수", 2
+            );
+            Long 오늘_예약_id = 오늘_예약.jsonPath().getLong("id");
+            String 오늘_예약_확인코드 = 오늘_예약.jsonPath().getString("confirmationCode");
+            예약_취소_요청(오늘_예약_id, 오늘_예약_확인코드);
+
+            // when - 수정을 요청한다
+            ExtractableResponse<Response> response = 예약_수정_요청(
+                    오늘_예약_id, 오늘_예약_확인코드,
+                    "2026-08-25", "2026-08-27"
+            );
+
+            // then - 수정이 거부된다
+            예약_수정_거부_검증(response);
+        }
+
+        @Test
+        @DisplayName("[예외] 수정 시 다른 예약과 충돌하면 거부")
+        void 수정시_다른_예약과_충돌_실패() {
+            // given - 다른 예약이 존재한다
+            예약_생성_요청("A-1", "2026-08-20", "2026-08-22", "김철수", 3);
+
+            // when - 충돌하는 날짜로 변경을 요청한다
+            ExtractableResponse<Response> response = 예약_수정_요청(
+                    reservationId, confirmationCode,
+                    "2026-08-20", "2026-08-22"
+            );
+
+            // then - 수정이 거부된다
+            예약_수정_거부_검증(response);
+        }
+    }
+}

--- a/src/test/java/com/camping/legacy/common/AcceptanceTest.java
+++ b/src/test/java/com/camping/legacy/common/AcceptanceTest.java
@@ -1,0 +1,31 @@
+package com.camping.legacy.common;
+
+import com.camping.legacy.CampingApplication;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@Import(DatabaseCleanup.class)
+@SpringBootTest(
+        classes = CampingApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+public abstract class AcceptanceTest {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    private DatabaseCleanup databaseCleanup;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        databaseCleanup.execute();
+    }
+}

--- a/src/test/java/com/camping/legacy/common/CalendarAssertions.java
+++ b/src/test/java/com/camping/legacy/common/CalendarAssertions.java
@@ -1,0 +1,60 @@
+package com.camping.legacy.common;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 캘린더 관련 Custom Assertions
+ */
+public class CalendarAssertions {
+
+    /**
+     * 특정 날짜가 예약 가능한지 검증
+     */
+    public static void 날짜가_예약가능_검증(ExtractableResponse<Response> response, String... dates) {
+        for (String date : dates) {
+            Boolean available = response.jsonPath()
+                    .getBoolean("days.find { it.date == '" + date + "' }.available");
+            assertThat(available)
+                    .as("날짜 %s는 예약 가능해야 합니다", date)
+                    .isTrue();
+        }
+    }
+
+    /**
+     * 특정 날짜가 예약됨 상태인지 검증
+     */
+    public static void 날짜가_예약됨_검증(ExtractableResponse<Response> response, String... dates) {
+        for (String date : dates) {
+            Boolean available = response.jsonPath()
+                    .getBoolean("days.find { it.date == '" + date + "' }.available");
+            assertThat(available)
+                    .as("날짜 %s는 예약됨 상태여야 합니다", date)
+                    .isFalse();
+        }
+    }
+
+    /**
+     * 캘린더 응답의 기본 정보 검증
+     */
+    public static void 캘린더_기본정보_검증(ExtractableResponse<Response> response,
+                                       int expectedYear, int expectedMonth, Long expectedSiteId) {
+        assertThat(response.jsonPath().getInt("year")).isEqualTo(expectedYear);
+        assertThat(response.jsonPath().getInt("month")).isEqualTo(expectedMonth);
+        assertThat(response.jsonPath().getLong("siteId")).isEqualTo(expectedSiteId);
+    }
+
+    /**
+     * 캘린더에 해당 월의 모든 날짜가 포함되어 있는지 검증
+     */
+    public static void 월별_날짜수_검증(ExtractableResponse<Response> response, int expectedDays) {
+        List<Object> days = response.jsonPath().getList("days");
+        assertThat(days)
+                .as("해당 월은 %d일이어야 합니다", expectedDays)
+                .hasSize(expectedDays);
+    }
+}

--- a/src/test/java/com/camping/legacy/common/DatabaseCleanup.java
+++ b/src/test/java/com/camping/legacy/common/DatabaseCleanup.java
@@ -1,0 +1,69 @@
+package com.camping.legacy.common;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Table;
+import jakarta.persistence.metamodel.EntityType;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class DatabaseCleanup {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private List<String> tableNames;
+
+    @Transactional
+    public void execute() {
+        entityManager.flush();
+
+        // 외래키 제약 조건 비활성화하여 삭제 순서 무시
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+
+        for (String tableName : getTableNames()) {
+            // 테이블 데이터 전체 삭제
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+            // ID 자동증가값을 1부터 다시 시작
+            entityManager.createNativeQuery(
+                    "ALTER TABLE " + tableName + " ALTER COLUMN ID RESTART WITH 1"
+            ).executeUpdate();
+        }
+        // 외래키 제약조건 다시 활성화
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+
+        // 기본 사이트 데이터 복원
+        insertDefaultSites();
+    }
+
+    private void insertDefaultSites() {
+        entityManager.createNativeQuery(
+                "INSERT INTO campsites (site_number, description, max_people) VALUES " +
+                        "('A-1', '대형 사이트 - 전기 있음', 6), " +
+                        "('A-2', '대형 사이트 - 전기 있음', 6), " +
+                        "('A-3', '대형 사이트 - 전기 있음', 6), " +
+                        "('B-1', '소형 사이트 - 전기 있음', 4), " +
+                        "('B-2', '소형 사이트 - 전기 있음', 4)"
+        ).executeUpdate();
+    }
+
+    private List<String> getTableNames() {
+        if (tableNames == null) {
+            tableNames = entityManager.getMetamodel().getEntities().stream()
+                    .filter(e -> e.getJavaType().getAnnotation(Entity.class) != null)
+                    .map(this::getTableName)
+                    .collect(Collectors.toList());
+        }
+        return tableNames;
+    }
+
+    private String getTableName(EntityType<?> entity) {
+        Table tableAnnotation = entity.getJavaType().getAnnotation(Table.class);
+        return tableAnnotation != null ? tableAnnotation.name() : entity.getName();
+    }
+}

--- a/src/test/java/com/camping/legacy/common/ReservationAssertions.java
+++ b/src/test/java/com/camping/legacy/common/ReservationAssertions.java
@@ -1,0 +1,91 @@
+package com.camping.legacy.common;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 예약 관련 Custom Assertions
+ */
+public class ReservationAssertions {
+
+    private static final int CONFIRMATION_CODE_LENGTH = 6;
+
+    /**
+     * 예약 생성 성공 검증
+     */
+    public static void 예약_생성_성공_검증(ExtractableResponse<Response> response, String expectedCustomerName) {
+        assertThat(response.statusCode())
+                .as("예약 생성이 성공해야 합니다")
+                .isEqualTo(HttpStatus.CREATED.value());
+        assertThat(response.jsonPath().getString("confirmationCode"))
+                .as("확인 코드가 생성되어야 합니다")
+                .hasSize(CONFIRMATION_CODE_LENGTH);
+        assertThat(response.jsonPath().getString("customerName"))
+                .as("고객명이 일치해야 합니다")
+                .isEqualTo(expectedCustomerName);
+    }
+
+    /**
+     * 예약 생성 성공 검증 (고객명 검증 없이)
+     */
+    public static void 예약_생성_성공_검증(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode())
+                .as("예약 생성이 성공해야 합니다")
+                .isEqualTo(HttpStatus.CREATED.value());
+        assertThat(response.jsonPath().getString("confirmationCode"))
+                .as("확인 코드가 생성되어야 합니다")
+                .hasSize(CONFIRMATION_CODE_LENGTH);
+    }
+
+    /**
+     * 예약 수정 성공 검증
+     */
+    public static void 예약_수정_성공_검증(ExtractableResponse<Response> response,
+                                     String expectedStartDate, String expectedEndDate) {
+        assertThat(response.statusCode())
+                .as("예약 수정이 성공해야 합니다")
+                .isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getString("startDate"))
+                .as("시작일이 변경되어야 합니다")
+                .isEqualTo(expectedStartDate);
+        assertThat(response.jsonPath().getString("endDate"))
+                .as("종료일이 변경되어야 합니다")
+                .isEqualTo(expectedEndDate);
+    }
+
+    /**
+     * 예약 충돌 오류 검증
+     */
+    public static void 예약_충돌_오류_검증(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode())
+                .as("예약 충돌로 거부되어야 합니다")
+                .isEqualTo(HttpStatus.CONFLICT.value());
+        assertThat(response.jsonPath().getString("message"))
+                .as("충돌 오류 메시지가 반환되어야 합니다")
+                .isEqualTo("해당 기간에 이미 예약이 존재합니다");
+    }
+
+    /**
+     * 예약 수정 거부 검증
+     */
+    public static void 예약_수정_거부_검증(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode())
+                .as("예약 수정이 거부되어야 합니다")
+                .isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    /**
+     * 취소된 예약 수정 시도 거부 검증
+     */
+    public static void 취소된_예약_수정_거부_검증(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode())
+                .as("취소된 예약 수정이 거부되어야 합니다")
+                .isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(response.jsonPath().getString("message"))
+                .as("취소된 예약 수정 오류 메시지가 반환되어야 합니다")
+                .isEqualTo("취소된 예약은 수정할 수 없습니다");
+    }
+}

--- a/src/test/java/com/camping/legacy/common/TestFixture.java
+++ b/src/test/java/com/camping/legacy/common/TestFixture.java
@@ -5,10 +5,57 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.springframework.http.MediaType;
 
+import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.HashMap;
 import java.util.Map;
 
 public class TestFixture {
+
+    // ==================== 날짜 헬퍼 ====================
+
+    /**
+     * 오늘 날짜 반환
+     */
+    public static String 오늘() {
+        return LocalDate.now().toString();
+    }
+
+    /**
+     * 오늘부터 N일 후 날짜 반환
+     */
+    public static String 오늘부터_N일_후(int days) {
+        return LocalDate.now().plusDays(days).toString();
+    }
+
+    /**
+     * 다음 달의 연도 반환
+     */
+    public static int 다음달_연도() {
+        return YearMonth.now().plusMonths(1).getYear();
+    }
+
+    /**
+     * 다음 달의 월 반환
+     */
+    public static int 다음달_월() {
+        return YearMonth.now().plusMonths(1).getMonthValue();
+    }
+
+    /**
+     * 다음 달의 총 일수 반환
+     */
+    public static int 다음달_일수() {
+        return YearMonth.now().plusMonths(1).lengthOfMonth();
+    }
+
+    /**
+     * 다음 달 특정 일자 반환 (e.g., 다음달_일자(10) -> "2026-02-10")
+     */
+    public static String 다음달_일자(int day) {
+        YearMonth nextMonth = YearMonth.now().plusMonths(1);
+        return LocalDate.of(nextMonth.getYear(), nextMonth.getMonth(), day).toString();
+    }
 
     // ==================== 사이트 관련 ====================
 

--- a/src/test/java/com/camping/legacy/common/TestFixture.java
+++ b/src/test/java/com/camping/legacy/common/TestFixture.java
@@ -1,0 +1,98 @@
+package com.camping.legacy.common;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestFixture {
+
+    // ==================== 사이트 관련 ====================
+
+    public static ExtractableResponse<Response> 전체_사이트_조회_요청() {
+        return RestAssured
+                .given().log().all()
+                .when().get("/api/sites")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 사이트_조회_요청(Long siteId) {
+        return RestAssured
+                .given().log().all()
+                .when().get("/api/sites/{siteId}", siteId)
+                .then().log().all()
+                .extract();
+    }
+
+    public static Long 사이트_ID_조회(String siteNumber) {
+        ExtractableResponse<Response> response = 전체_사이트_조회_요청();
+        return response.jsonPath().getLong("find { it.siteNumber == '" + siteNumber + "' }.id");
+    }
+
+    // ==================== 예약 관련 ====================
+
+    public static ExtractableResponse<Response> 예약_생성_요청(
+            String siteNumber, String startDate, String endDate,
+            String customerName, int numberOfPeople) {
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("siteNumber", siteNumber);
+        params.put("startDate", startDate);
+        params.put("endDate", endDate);
+        params.put("customerName", customerName);
+        params.put("numberOfPeople", numberOfPeople);
+        params.put("phoneNumber", "010-1234-5678");
+
+        return RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(params)
+                .when().post("/api/reservations")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 예약_수정_요청(
+            Long reservationId, String confirmationCode,
+            String startDate, String endDate) {
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("startDate", startDate);
+        params.put("endDate", endDate);
+
+        return RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .queryParam("confirmationCode", confirmationCode)
+                .body(params)
+                .when().put("/api/reservations/{id}", reservationId)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 예약_취소_요청(Long id, String confirmationCode) {
+        return RestAssured
+                .given().log().all()
+                .queryParam("confirmationCode", confirmationCode)
+                .when().delete("/api/reservations/{id}", id)
+                .then().log().all()
+                .extract();
+    }
+
+    // ==================== 캘린더 관련 ====================
+
+    public static ExtractableResponse<Response> 캘린더_조회_요청(Long siteId, int year, int month) {
+        return RestAssured
+                .given().log().all()
+                .queryParam("siteId", siteId)
+                .queryParam("year", year)
+                .queryParam("month", month)
+                .when().get("/api/reservations/calendar")
+                .then().log().all()
+                .extract();
+    }
+}


### PR DESCRIPTION
- 정상 케이스, 예외 케이스 작성
- TestFixture로 중복 코드 최소화

### 새로 알게 된 것들
- `@Sql`
  - 테스트 실행 전/후에 SQL 스크립트를 직접 실행
  - 특정 테스트에 필요한 데이터만 명시적으로 세팅/정리할 때 적합

- DatabaseCleanup
  - 모든 테이블을 대상으로 데이터를 일괄 정리
  - 테스트 간 완전한 DB 초기화 보장
  - 테스트 수가 많아질수록 성능 비용이 커질 수 있음

- @DirtiesContext
  - 테스트 후 Spring ApplicationContext를 폐기하고 재생성
  - 빈 상태 오염 방지에는 확실하지만 가장 비용이 큼
  - 정말 필요한 경우(전역 상태 변경 테스트)에만 사용 권장